### PR TITLE
Use ENV for api url

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosError } from 'axios'
 
 const API = axios.create({
-  baseURL: 'https://admin.dev.climatepolicyradar.org/api/',
+  baseURL: process.env.API_URL ?? 'https://admin.dev.climatepolicyradar.org/api/',
   headers: {
     'Content-Type': 'application/json',
   },


### PR DESCRIPTION
This has not been tested - but this change should use the env var `API_URL` for making calls to the API and not the hardcoded staging - tho this is still used by default