### PR TITLE
Remove default search, incorrect copy, handling empty lists

### DIFF
--- a/src/api/Documents.ts
+++ b/src/api/Documents.ts
@@ -8,7 +8,7 @@ export async function getDocuments(query: string | undefined | null) {
   setToken(API)
 
   const response = await API.get<IDocument[]>('/v1/documents/', {
-    params: { q: query || 'carbon' },
+    params: { q: query },
   })
     .then((response) => {
       return response.data

--- a/src/api/Families.ts
+++ b/src/api/Families.ts
@@ -27,11 +27,7 @@ export async function getFamilies({
 
   // For API performance reasons (search will timeout if too many results are returned)
   // if there is no search, default to using 'redd'
-  const defaultQuery = query
-    ? query
-    : !geography && !status
-      ? 'redd'
-      : undefined
+  const defaultQuery = query ?? ''
 
   const searchParams: TSearchParams = {
     q: defaultQuery,

--- a/src/api/Families.ts
+++ b/src/api/Families.ts
@@ -25,12 +25,8 @@ export async function getFamilies({
 }: TFamilySearchQuery) {
   setToken(API)
 
-  // For API performance reasons (search will timeout if too many results are returned)
-  // if there is no search, default to using 'redd'
-  const defaultQuery = query ?? ''
-
   const searchParams: TSearchParams = {
-    q: defaultQuery,
+    q: query ?? '',
   }
   if (geography) {
     searchParams['geography'] = geography

--- a/src/components/lists/CollectionList.tsx
+++ b/src/components/lists/CollectionList.tsx
@@ -138,6 +138,11 @@ export default function CollectionList() {
                 </Tr>
               </Thead>
               <Tbody>
+                {filteredItems.length === 0 && (
+                  <Tr>
+                    <Td colSpan={4}>No results found, please amend your search</Td>
+                  </Tr>
+                )}
                 {filteredItems.map((collection) => (
                   <Tr
                     key={collection.import_id}

--- a/src/components/lists/CollectionList.tsx
+++ b/src/components/lists/CollectionList.tsx
@@ -31,7 +31,7 @@ export default function CollectionList() {
     key: keyof ICollection
     reverse: boolean
   }>({ key: 'import_id', reverse: false })
-  const [filteredItems, setFilteredItems] = useState<ICollection[]>([])
+  const [filteredItems, setFilteredItems] = useState<ICollection[]>()
   const [searchParams] = useSearchParams()
   const { collections, loading, error, reload } = useCollections(
     searchParams.get('q') ?? '',
@@ -138,12 +138,12 @@ export default function CollectionList() {
                 </Tr>
               </Thead>
               <Tbody>
-                {filteredItems.length === 0 && (
+                {filteredItems?.length === 0 && (
                   <Tr>
                     <Td colSpan={4}>No results found, please amend your search</Td>
                   </Tr>
                 )}
-                {filteredItems.map((collection) => (
+                {filteredItems?.map((collection) => (
                   <Tr
                     key={collection.import_id}
                     borderLeft={

--- a/src/components/lists/DocumentList.tsx
+++ b/src/components/lists/DocumentList.tsx
@@ -138,6 +138,11 @@ export default function DocumentList() {
                 </Tr>
               </Thead>
               <Tbody>
+                {filteredItems.length === 0 && (
+                  <Tr>
+                    <Td colSpan={3}>No results found, please amend your search</Td>
+                  </Tr>
+                )}
                 {filteredItems.map((document) => (
                   <Tr
                     key={document.import_id}

--- a/src/components/lists/DocumentList.tsx
+++ b/src/components/lists/DocumentList.tsx
@@ -33,7 +33,7 @@ export default function DocumentList() {
     key: keyof IDocument
     reverse: boolean
   }>({ key: 'import_id', reverse: false })
-  const [filteredItems, setFilteredItems] = useState<IDocument[]>([])
+  const [filteredItems, setFilteredItems] = useState<IDocument[]>()
   const [searchParams] = useSearchParams()
   const { documents, loading, error, reload } = useDocuments(
     searchParams.get('q') ?? '',
@@ -138,12 +138,12 @@ export default function DocumentList() {
                 </Tr>
               </Thead>
               <Tbody>
-                {filteredItems.length === 0 && (
+                {filteredItems?.length === 0 && (
                   <Tr>
                     <Td colSpan={3}>No results found, please amend your search</Td>
                   </Tr>
                 )}
-                {filteredItems.map((document) => (
+                {filteredItems?.map((document) => (
                   <Tr
                     key={document.import_id}
                     borderLeft={

--- a/src/components/lists/FamilyList.tsx
+++ b/src/components/lists/FamilyList.tsx
@@ -167,6 +167,11 @@ export default function FamilyList() {
             </Tr>
           </Thead>
           <Tbody>
+            {filteredItems.length === 0 && (
+              <Tr>
+                <Td colSpan={8}>No results found, please amend your search</Td>
+              </Tr>
+            )}
             {filteredItems.map((family) => (
               <Tr
                 key={family.import_id}

--- a/src/components/lists/FamilyList.tsx
+++ b/src/components/lists/FamilyList.tsx
@@ -56,7 +56,7 @@ export default function FamilyList() {
     key: keyof TFamily
     reverse: boolean
   }>({ key: 'slug', reverse: false })
-  const [filteredItems, setFilteredItems] = useState<TFamily[]>([])
+  const [filteredItems, setFilteredItems] = useState<TFamily[]>()
   const {
     response: { data: families },
   } = useLoaderData() as { response: { data: TFamily[] } }
@@ -167,12 +167,12 @@ export default function FamilyList() {
             </Tr>
           </Thead>
           <Tbody>
-            {filteredItems.length === 0 && (
+            {filteredItems?.length === 0 && (
               <Tr>
                 <Td colSpan={8}>No results found, please amend your search</Td>
               </Tr>
             )}
-            {filteredItems.map((family) => (
+            {filteredItems?.map((family) => (
               <Tr
                 key={family.import_id}
                 borderLeft={

--- a/src/views/collection/Collections.tsx
+++ b/src/views/collection/Collections.tsx
@@ -22,7 +22,7 @@ export default function Collections() {
         <Box>
           <Heading as={'h1'}>Collections</Heading>
         </Box>
-        <Box>
+        <Box flex="1">
           <Form id="search-form" role="search">
             <HStack spacing="0">
               <Input
@@ -33,6 +33,7 @@ export default function Collections() {
                 name="q"
                 defaultValue={searchParams.get('q') ?? ''}
                 roundedRight={0}
+                maxW="600px"
               />
               <IconButton
                 type="submit"

--- a/src/views/dashboard/Dashboard.tsx
+++ b/src/views/dashboard/Dashboard.tsx
@@ -62,7 +62,6 @@ const Dashboard = () => {
               <Stat>
                 <StatLabel>Events</StatLabel>
                 <StatNumber>{summary?.n_events}</StatNumber>
-                <StatHelpText>Click here to view Events</StatHelpText>
               </Stat>
             </CardBody>
           </Card>


### PR DESCRIPTION
- Default search removed, to allow blank query
- Remove "click here" copy when not a link
- Add empty list handling for Families, Documents, Collections