### PR TITLE
PDCT-721/change_deleted_text_for_no_documents

### DIFF
--- a/src/components/lists/FamilyList.tsx
+++ b/src/components/lists/FamilyList.tsx
@@ -25,6 +25,7 @@ import { DeleteButton } from '../buttons/Delete'
 import { sortBy } from '@/utils/sortBy'
 import { ArrowDownIcon, ArrowUpIcon, ArrowUpDownIcon } from '@chakra-ui/icons'
 import { getStatusColour } from '@/utils/getStatusColour'
+import { getStatusAlias } from '@/utils/getStatusAlias'
 import { ApiError } from '../feedback/ApiError'
 
 interface ILoaderProps {
@@ -218,7 +219,7 @@ export default function FamilyList() {
                 <Td>{formatDate(family.last_modified)}</Td>
                 <Td>
                   <Badge colorScheme={getStatusColour(family.status)} size="sm">
-                    {family.status}
+                    {getStatusAlias(family.status)}
                   </Badge>
                 </Td>
                 <Td>

--- a/src/utils/getStatusAlias.ts
+++ b/src/utils/getStatusAlias.ts
@@ -1,0 +1,9 @@
+export const getStatusAlias = (status?: string | null) => {
+  if (!status) return ''
+  switch (status.toLowerCase()) {
+    case 'deleted':
+      return 'NO DOCUMENTS'
+    default:
+      return status
+  }
+}


### PR DESCRIPTION
Create an alias function to rename the status for "DELETED" families to "NO DOCUMENTS" instead.

Manually tested only