### PR TITLE
PDCT-720 Use chakra react select and sort the language list using cache

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -29,5 +29,5 @@ module.exports = {
     ],
   },
   // ignore js files
-  ignorePatterns: ['.eslintrc.cjs', 'vite.config.ts', '**/*.js'],
+  ignorePatterns: ['.eslintrc.cjs', 'vite.config.ts', '**/*.js', 'src/tests'],
 }

--- a/src/api/Documents.ts
+++ b/src/api/Documents.ts
@@ -2,7 +2,7 @@ import { AxiosError } from 'axios'
 
 import API from '@/api'
 import { setToken } from '@/api/Auth'
-import { IDocument, IDocumentFormPost, IError } from '@/interfaces'
+import { IDocument, IDocumentFormPostModified, IError } from '@/interfaces'
 
 export async function getDocuments(query: string | undefined | null) {
   setToken(API)
@@ -44,7 +44,7 @@ export async function getDocument(id: string) {
   return { response }
 }
 
-export async function createDocument(data: IDocumentFormPost) {
+export async function createDocument(data: IDocumentFormPostModified) {
   setToken(API)
 
   const response = await API.post<string>('/v1/documents', data)
@@ -63,7 +63,7 @@ export async function createDocument(data: IDocumentFormPost) {
   return { response }
 }
 
-export async function updateDocument(data: IDocumentFormPost, id: string) {
+export async function updateDocument(data: IDocumentFormPostModified, id: string) {
   setToken(API)
 
   const response = await API.put<IDocument>('/v1/documents/' + id, data)

--- a/src/api/Documents.ts
+++ b/src/api/Documents.ts
@@ -63,7 +63,10 @@ export async function createDocument(data: IDocumentFormPostModified) {
   return { response }
 }
 
-export async function updateDocument(data: IDocumentFormPostModified, id: string) {
+export async function updateDocument(
+  data: IDocumentFormPostModified,
+  id: string,
+) {
   setToken(API)
 
   const response = await API.put<IDocument>('/v1/documents/' + id, data)

--- a/src/components/forms/DocumentForm.tsx
+++ b/src/components/forms/DocumentForm.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useState } from 'react'
 import { useForm, SubmitHandler, Controller } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
-import { IDocument, IDocumentFormPost, IDocumentFormPostModified, IError } from '@/interfaces'
+import {
+  IDocument,
+  IDocumentFormPost,
+  IDocumentFormPostModified,
+  IError,
+} from '@/interfaces'
 import { createDocument, updateDocument } from '@/api/Documents'
 import { documentSchema } from '@/schemas/documentSchema'
 import { Select as CRSelect } from 'chakra-react-select'
@@ -53,15 +58,17 @@ export const DocumentForm = ({
   ) => {
     setFormError(null)
 
-    const convertToModified = (data: IDocumentFormPost): IDocumentFormPostModified => {
+    const convertToModified = (
+      data: IDocumentFormPost,
+    ): IDocumentFormPostModified => {
       return {
         ...data,
         variant_name: submittedDcumentData.variant_name || null,
         user_language_name: data.user_language_name?.label || null,
-      };
-    };
-    
-    const modifiedDocumentData = convertToModified(submittedDcumentData);
+      }
+    }
+
+    const modifiedDocumentData = convertToModified(submittedDcumentData)
 
     // const documentData = {
     //   ...submittedDcumentData,
@@ -69,7 +76,10 @@ export const DocumentForm = ({
     // }
 
     if (loadedDocument) {
-      return await updateDocument(modifiedDocumentData, loadedDocument.import_id)
+      return await updateDocument(
+        modifiedDocumentData,
+        loadedDocument.import_id,
+      )
         .then((data) => {
           toast.closeAll()
           toast({
@@ -126,7 +136,10 @@ export const DocumentForm = ({
         type: loadedDocument.type ?? '',
         title: loadedDocument.title,
         source_url: loadedDocument.source_url ?? '',
-        user_language_name: { label: loadedDocument.user_language_name ?? '', value: loadedDocument.user_language_name ?? '' },
+        user_language_name: {
+          label: loadedDocument.user_language_name ?? '',
+          value: loadedDocument.user_language_name ?? '',
+        },
       })
     } else if (familyId) {
       reset({

--- a/src/components/forms/DocumentForm.tsx
+++ b/src/components/forms/DocumentForm.tsx
@@ -70,11 +70,6 @@ export const DocumentForm = ({
 
     const modifiedDocumentData = convertToModified(submittedDcumentData)
 
-    // const documentData = {
-    //   ...submittedDcumentData,
-    //   variant_name: submittedDcumentData.variant_name || null,
-    // }
-
     if (loadedDocument) {
       return await updateDocument(
         modifiedDocumentData,

--- a/src/components/forms/DocumentForm.tsx
+++ b/src/components/forms/DocumentForm.tsx
@@ -249,14 +249,16 @@ export const DocumentForm = ({
                   isInvalid={!!errors.user_language_name}
                 >
                   <FormLabel as="legend">Language</FormLabel>
-                  <CRSelect
-                    chakraStyles={chakraStylesSelect}
-                    isClearable={false}
-                    isMulti={false}
-                    isSearchable={true}
-                    options={config?.languagesSorted}
-                    {...field}
-                  />
+                  <div data-testid="language-select">
+                    <CRSelect
+                      chakraStyles={chakraStylesSelect}
+                      isClearable={false}
+                      isMulti={false}
+                      isSearchable={true}
+                      options={config?.languagesSorted}
+                      {...field}
+                    />
+                  </div>
                   <FormErrorMessage>
                     {errors.user_language_name?.message}
                   </FormErrorMessage>

--- a/src/components/forms/DocumentForm.tsx
+++ b/src/components/forms/DocumentForm.tsx
@@ -4,6 +4,7 @@ import { yupResolver } from '@hookform/resolvers/yup'
 import { IDocument, IDocumentFormPost, IError } from '@/interfaces'
 import { createDocument, updateDocument } from '@/api/Documents'
 import { documentSchema } from '@/schemas/documentSchema'
+import { Select as CRSelect } from 'chakra-react-select'
 
 import {
   Box,
@@ -22,6 +23,7 @@ import {
 import useConfig from '@/hooks/useConfig'
 import { FormLoader } from '../feedback/FormLoader'
 import { ApiError } from '../feedback/ApiError'
+import { chakraStylesSelect } from '@/styles/chakra'
 
 type TProps = {
   document?: IDocument
@@ -46,7 +48,6 @@ export const DocumentForm = ({
   } = useForm({
     resolver: yupResolver(documentSchema),
   })
-
   const handleFormSubmission = async (
     submittedDcumentData: IDocumentFormPost,
   ) => {
@@ -55,7 +56,6 @@ export const DocumentForm = ({
     const documentData = {
       ...submittedDcumentData,
       variant_name: submittedDcumentData.variant_name || null,
-      user_language_name: submittedDcumentData.user_language_name || null,
     }
 
     if (loadedDocument) {
@@ -226,15 +226,17 @@ export const DocumentForm = ({
                   isInvalid={!!errors.user_language_name}
                 >
                   <FormLabel as="legend">Language</FormLabel>
-                  <Select background="white" {...field}>
-                    <option value="">Please select</option>
-                    {Object.keys(config?.languages || {}).map((key) => (
-                      <option key={key} value={config?.languages[key]}>
-                        {config?.languages[key]}
-                      </option>
-                    ))}
-                  </Select>
-                  <FormErrorMessage>Please select a language</FormErrorMessage>
+                  <CRSelect
+                    chakraStyles={chakraStylesSelect}
+                    isClearable={false}
+                    isMulti={false}
+                    isSearchable={true}
+                    options={config?.languagesSorted}
+                    {...field}
+                  />
+                  <FormErrorMessage>
+                    {errors.user_language_name?.message}
+                  </FormErrorMessage>
                 </FormControl>
               )
             }}

--- a/src/components/forms/DocumentForm.tsx
+++ b/src/components/forms/DocumentForm.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useForm, SubmitHandler, Controller } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
-import { IDocument, IDocumentFormPost, IError } from '@/interfaces'
+import { IDocument, IDocumentFormPost, IDocumentFormPostModified, IError } from '@/interfaces'
 import { createDocument, updateDocument } from '@/api/Documents'
 import { documentSchema } from '@/schemas/documentSchema'
 import { Select as CRSelect } from 'chakra-react-select'
@@ -53,13 +53,23 @@ export const DocumentForm = ({
   ) => {
     setFormError(null)
 
-    const documentData = {
-      ...submittedDcumentData,
-      variant_name: submittedDcumentData.variant_name || null,
-    }
+    const convertToModified = (data: IDocumentFormPost): IDocumentFormPostModified => {
+      return {
+        ...data,
+        variant_name: submittedDcumentData.variant_name || null,
+        user_language_name: data.user_language_name?.label || null,
+      };
+    };
+    
+    const modifiedDocumentData = convertToModified(submittedDcumentData);
+
+    // const documentData = {
+    //   ...submittedDcumentData,
+    //   variant_name: submittedDcumentData.variant_name || null,
+    // }
 
     if (loadedDocument) {
-      return await updateDocument(documentData, loadedDocument.import_id)
+      return await updateDocument(modifiedDocumentData, loadedDocument.import_id)
         .then((data) => {
           toast.closeAll()
           toast({
@@ -80,7 +90,7 @@ export const DocumentForm = ({
         })
     }
 
-    return await createDocument(documentData)
+    return await createDocument(modifiedDocumentData)
       .then((data) => {
         toast.closeAll()
         toast({
@@ -116,7 +126,7 @@ export const DocumentForm = ({
         type: loadedDocument.type ?? '',
         title: loadedDocument.title,
         source_url: loadedDocument.source_url ?? '',
-        user_language_name: loadedDocument.user_language_name ?? '',
+        user_language_name: { label: loadedDocument.user_language_name ?? '', value: loadedDocument.user_language_name ?? '' },
       })
     } else if (familyId) {
       reset({

--- a/src/hooks/useConfig.ts
+++ b/src/hooks/useConfig.ts
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 
 import { IError, IConfig } from '@/interfaces'
 import { getConfig } from '@/api/Config'
-import { configureConfig } from '@/utils/configureConfig'
+import { modifyConfig } from '@/utils/modifyConfig'
 
 let cache: IConfig | null = null
 
@@ -24,7 +24,7 @@ const useConfig = () => {
     getConfig()
       .then(({ response }) => {
         if (!ignore) {
-          cache = configureConfig(response)
+          cache = modifyConfig(response)
           setConfig(cache)
         }
       })

--- a/src/hooks/useConfig.ts
+++ b/src/hooks/useConfig.ts
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 
 import { IError, IConfig } from '@/interfaces'
 import { getConfig } from '@/api/Config'
+import { configureConfig } from '@/utils/configureConfig'
 
 let cache: IConfig | null = null
 
@@ -23,8 +24,8 @@ const useConfig = () => {
     getConfig()
       .then(({ response }) => {
         if (!ignore) {
-          cache = response
-          setConfig(response)
+          cache = configureConfig(response)
+          setConfig(cache)
         }
       })
       .catch((error: IError) => {

--- a/src/interfaces/Config.ts
+++ b/src/interfaces/Config.ts
@@ -18,11 +18,17 @@ interface IConfigMeta {
   allowed_values: string[]
 }
 
+export interface IConfigLangaugeSorted {
+  value: string
+  label: string
+}
+
 export interface IConfig {
   geographies: IConfigGeography[]
   languages: {
     [key: string]: string
   }
+  languagesSorted: IConfigLangaugeSorted[]
   taxonomies: {
     CCLW: {
       topic: IConfigMeta

--- a/src/interfaces/Document.ts
+++ b/src/interfaces/Document.ts
@@ -23,9 +23,9 @@ export interface IDocumentFormPost {
   title: string
   source_url: string
   user_language_name?: {
-    label: string;
-    value: string;
-  } | null;
+    label: string
+    value: string
+  } | null
 }
 
 export interface IDocumentFormPostModified {

--- a/src/interfaces/Document.ts
+++ b/src/interfaces/Document.ts
@@ -22,5 +22,18 @@ export interface IDocumentFormPost {
   type: string
   title: string
   source_url: string
+  user_language_name?: {
+    label: string;
+    value: string;
+  } | null;
+}
+
+export interface IDocumentFormPostModified {
+  family_import_id: string
+  variant_name?: string | null
+  role: string
+  type: string
+  title: string
+  source_url: string
   user_language_name?: string | null
 }

--- a/src/schemas/documentSchema.ts
+++ b/src/schemas/documentSchema.ts
@@ -1,4 +1,5 @@
 import * as yup from 'yup'
+import { IConfigLangaugeSorted } from '@/interfaces'
 
 export const documentSchema = yup
   .object({
@@ -8,6 +9,12 @@ export const documentSchema = yup
     type: yup.string().required(),
     title: yup.string().required(),
     source_url: yup.string().url().required(),
-    user_language_name: yup.string().optional(),
+    user_language_name: yup
+      .string()
+      .optional()
+      .transform((_, originalValue: IConfigLangaugeSorted): string => {
+        const value: IConfigLangaugeSorted | null = originalValue ? originalValue : null;
+        return value ? value.label : '';
+      }),
   })
   .required()

--- a/src/schemas/documentSchema.ts
+++ b/src/schemas/documentSchema.ts
@@ -1,5 +1,4 @@
 import * as yup from 'yup'
-import { IConfigLangaugeSorted } from '@/interfaces'
 
 export const documentSchema = yup
   .object({
@@ -10,11 +9,10 @@ export const documentSchema = yup
     title: yup.string().required(),
     source_url: yup.string().url().required(),
     user_language_name: yup
-      .string()
-      .optional()
-      .transform((_, originalValue: IConfigLangaugeSorted): string => {
-        const value: IConfigLangaugeSorted | null = originalValue ? originalValue : null;
-        return value ? value.label : '';
-      }),
+      .object({
+        label: yup.string().required(),
+        value: yup.string().required(),
+      })
+      .optional(),
   })
   .required()

--- a/src/tests/components/forms/DocumentForm.test.tsx
+++ b/src/tests/components/forms/DocumentForm.test.tsx
@@ -2,8 +2,24 @@ import '@testing-library/jest-dom'
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import { DocumentForm } from '@/components/forms/DocumentForm'
 import { IDocument } from '@/interfaces'
+import { ChakraProvider } from '@chakra-ui/react'
 
-// Mocks
+import React from 'react'
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // Deprecated
+    removeListener: jest.fn(), // Deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+})
+
 jest.mock('@/api/Documents', () => ({
   createDocument: jest
     .fn()
@@ -55,11 +71,15 @@ const mockDocument: IDocument = {
 describe('DocumentForm', () => {
   it('validate incorrect document URL', async () => {
     render(
-      <DocumentForm
-        familyId={'test'}
-        onSuccess={onDocumentFormSuccess}
-        document={mockDocument}
-      />,
+      <React.StrictMode>
+        <ChakraProvider>
+          <DocumentForm
+            familyId={'test'}
+            onSuccess={onDocumentFormSuccess}
+            document={mockDocument}
+          />
+        </ChakraProvider>
+      </React.StrictMode>,
     )
 
     const input = screen.getByRole('textbox', { name: /source url/i })
@@ -80,11 +100,15 @@ describe('DocumentForm', () => {
 
   it('validate correct document URL', async () => {
     render(
-      <DocumentForm
-        familyId={'test'}
-        onSuccess={onDocumentFormSuccess}
-        document={mockDocument}
-      />,
+      <React.StrictMode>
+        <ChakraProvider>
+          <DocumentForm
+            familyId={'test'}
+            onSuccess={onDocumentFormSuccess}
+            document={mockDocument}
+          />
+        </ChakraProvider>
+      </React.StrictMode>,
     )
 
     const input = screen.getByRole('textbox', { name: /source url/i })

--- a/src/tests/components/forms/DocumentForm.test.tsx
+++ b/src/tests/components/forms/DocumentForm.test.tsx
@@ -119,16 +119,6 @@ describe('DocumentForm', () => {
       throw new Error('Dropdown not found')
     }
 
-    // TODO: Check both options are visible and select one
-    // expect(screen.getByRole("form")).toHaveFormValues({ animals: "cat" });
-
-    // await waitFor(() => {
-    //   expect(screen.getByText('Spanish')).toBeInTheDocument();
-    //   expect(screen.getByText('English')).toBeInTheDocument();
-    //   const option = screen.getByText("Spanish");
-    //   fireEvent.click(option);
-    // });
-
     // Check no errors at submit
     fireEvent.submit(submitButton)
     await waitFor(() => {

--- a/src/tests/components/forms/DocumentForm.test.tsx
+++ b/src/tests/components/forms/DocumentForm.test.tsx
@@ -1,24 +1,8 @@
 import '@testing-library/jest-dom'
-import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { screen, waitFor, fireEvent } from '@testing-library/react'
+import { customRender } from '@/tests/utilsTest/render'
 import { DocumentForm } from '@/components/forms/DocumentForm'
 import { IDocument } from '@/interfaces'
-import { ChakraProvider } from '@chakra-ui/react'
-
-import React from 'react'
-
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: jest.fn().mockImplementation((query: string) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: jest.fn(), // Deprecated
-    removeListener: jest.fn(), // Deprecated
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
-    dispatchEvent: jest.fn(),
-  })),
-})
 
 jest.mock('@/api/Documents', () => ({
   createDocument: jest
@@ -28,27 +12,6 @@ jest.mock('@/api/Documents', () => ({
     .fn()
     .mockResolvedValue({ response: { documentId: 'some-id' } }),
 }))
-
-jest.mock('@/hooks/useConfig', () => ({
-  __esModule: true,
-  default: jest.fn(() => ({
-    config: {
-      document: {
-        roles: ['role1', 'role2'],
-        types: ['type1', 'type2'],
-        variants: ['variant1', 'variant2'],
-      },
-      languages: {
-        en: 'English',
-        es: 'Spanish',
-      },
-    },
-    loading: false,
-    error: null,
-  })),
-}))
-
-const onDocumentFormSuccess = jest.fn()
 
 const mockDocument: IDocument = {
   import_id: '12345',
@@ -64,22 +27,24 @@ const mockDocument: IDocument = {
   cdn_object: 'cdn/path/to/document',
   source_url: 'http://example.com/document',
   content_type: 'application/pdf',
-  user_language_name: 'English',
+  user_language_name: 'Default language',
 }
 
 // Tests
 describe('DocumentForm', () => {
+  const onDocumentFormSuccess = jest.fn()
+
+  beforeEach(() => {
+    onDocumentFormSuccess.mockReset()
+  })
+
   it('validate incorrect document URL', async () => {
-    render(
-      <React.StrictMode>
-        <ChakraProvider>
-          <DocumentForm
-            familyId={'test'}
-            onSuccess={onDocumentFormSuccess}
-            document={mockDocument}
-          />
-        </ChakraProvider>
-      </React.StrictMode>,
+    customRender(
+      <DocumentForm
+        familyId={'test'}
+        onSuccess={onDocumentFormSuccess}
+        document={mockDocument}
+      />,
     )
 
     const input = screen.getByRole('textbox', { name: /source url/i })
@@ -99,16 +64,12 @@ describe('DocumentForm', () => {
   })
 
   it('validate correct document URL', async () => {
-    render(
-      <React.StrictMode>
-        <ChakraProvider>
-          <DocumentForm
-            familyId={'test'}
-            onSuccess={onDocumentFormSuccess}
-            document={mockDocument}
-          />
-        </ChakraProvider>
-      </React.StrictMode>,
+    customRender(
+      <DocumentForm
+        familyId={'test'}
+        onSuccess={onDocumentFormSuccess}
+        document={mockDocument}
+      />,
     )
 
     const input = screen.getByRole('textbox', { name: /source url/i })
@@ -121,6 +82,55 @@ describe('DocumentForm', () => {
     })
     fireEvent.submit(submitButton)
 
+    await waitFor(() => {
+      expect(onDocumentFormSuccess).toHaveBeenCalled()
+    })
+  })
+
+  it('allows selecting a language', async () => {
+    customRender(
+      <DocumentForm
+        familyId={'test'}
+        onSuccess={onDocumentFormSuccess}
+        document={mockDocument}
+      />,
+    )
+
+    const languageDropdown = screen.getByTestId('language-select')
+    const submitButton = screen.getByText('Update Document')
+
+    expect(languageDropdown).toBeDefined()
+    expect(languageDropdown).not.toBeNull()
+    expect(submitButton).toBeDefined()
+    expect(submitButton).not.toBeNull()
+
+    // Original language as default
+    await waitFor(() => {
+      expect(screen.getByText('Default language')).toBeInTheDocument()
+    })
+
+    // Open the dropdown
+    const languageSelectDropdown = screen
+      .getByTestId('language-select')
+      .querySelector('div')
+    if (languageSelectDropdown) {
+      fireEvent.click(languageSelectDropdown)
+    } else {
+      throw new Error('Dropdown not found')
+    }
+
+    // TODO: Check both options are visible and select one
+    // expect(screen.getByRole("form")).toHaveFormValues({ animals: "cat" });
+
+    // await waitFor(() => {
+    //   expect(screen.getByText('Spanish')).toBeInTheDocument();
+    //   expect(screen.getByText('English')).toBeInTheDocument();
+    //   const option = screen.getByText("Spanish");
+    //   fireEvent.click(option);
+    // });
+
+    // Check no errors at submit
+    fireEvent.submit(submitButton)
     await waitFor(() => {
       expect(onDocumentFormSuccess).toHaveBeenCalled()
     })

--- a/src/tests/utils/modifyConfig.test.ts
+++ b/src/tests/utils/modifyConfig.test.ts
@@ -1,0 +1,115 @@
+import { IConfig } from '@/interfaces'
+import { modifyConfig } from '@utils/modifyConfig'
+
+describe('modifyConfig', () => {
+  it('should add a languagesSorted property to the config object with languages sorted alphabetically by label', () => {
+    const mockConfig: IConfig = {
+      document: {
+        roles: ['role1', 'role2'],
+        types: ['type1', 'type2'],
+        variants: ['variant1', 'variant2'],
+      },
+      languages: {
+        en: 'English',
+        es: 'Spanish',
+      },
+      geographies: [
+        {
+          node: {
+            id: 1,
+            display_value: 'MockNode',
+            slug: 'mock-node',
+            value: 'mockNode',
+            type: 'mockType',
+            parent_id: 0,
+          },
+          children: [],
+        },
+      ],
+      languagesSorted: [],
+      taxonomies: {
+        CCLW: {
+          topic: { allow_blanks: false, allowed_values: ['topic1', 'topic2'] },
+          hazard: {
+            allow_blanks: false,
+            allowed_values: ['hazard1', 'hazard2'],
+          },
+          sector: {
+            allow_blanks: false,
+            allowed_values: ['sector1', 'sector2'],
+          },
+          keyword: {
+            allow_blanks: false,
+            allowed_values: ['keyword1', 'keyword2'],
+          },
+          framework: {
+            allow_blanks: false,
+            allowed_values: ['framework1', 'framework2'],
+          },
+          instrument: {
+            allow_blanks: false,
+            allowed_values: ['instrument1', 'instrument2'],
+          },
+        },
+        UNFCCC: {
+          author: {
+            allow_blanks: false,
+            allowed_values: ['author1', 'author2'],
+          },
+          author_type: {
+            allow_blanks: false,
+            allowed_values: ['authorType1', 'authorType2'],
+          },
+        },
+      },
+      event: {
+        types: ['type1', 'type2'],
+      },
+    }
+
+    const expectedLanguagesSorted = [
+      { value: 'en', label: 'English' },
+      { value: 'es', label: 'Spanish' },
+    ]
+
+    const modifiedConfig = modifyConfig(mockConfig)
+    expect(modifiedConfig).toHaveProperty('languagesSorted')
+    expect(modifiedConfig.languagesSorted).toEqual(
+      expect.arrayContaining(expectedLanguagesSorted),
+    )
+  })
+
+  it('should handle empty languages object', () => {
+    const mockConfig: IConfig = {
+      document: {
+        roles: ['role1', 'role2'],
+        types: ['type1', 'type2'],
+        variants: ['variant1', 'variant2'],
+      },
+      languages: {},
+      geographies: [],
+      languagesSorted: [],
+      taxonomies: {
+        CCLW: {
+          topic: { allow_blanks: false, allowed_values: [] },
+          hazard: { allow_blanks: false, allowed_values: [] },
+          sector: { allow_blanks: false, allowed_values: [] },
+          keyword: { allow_blanks: false, allowed_values: [] },
+          framework: { allow_blanks: false, allowed_values: [] },
+          instrument: { allow_blanks: false, allowed_values: [] },
+        },
+        UNFCCC: {
+          author: { allow_blanks: false, allowed_values: [] },
+          author_type: { allow_blanks: false, allowed_values: [] },
+        },
+      },
+      event: {
+        types: [],
+      },
+    }
+
+    const modifiedConfig = modifyConfig(mockConfig)
+    expect(modifiedConfig).toHaveProperty('languagesSorted')
+    expect(modifiedConfig.languagesSorted).toEqual([])
+  })
+})

--- a/src/tests/utilsTest/mocks.tsx
+++ b/src/tests/utilsTest/mocks.tsx
@@ -1,0 +1,27 @@
+const useConfigMock = jest.fn(() => ({
+  config: {
+    document: {
+      roles: ['role1', 'role2'],
+      types: ['type1', 'type2'],
+      variants: ['variant1', 'variant2'],
+    },
+    languages: {
+      en: 'English',
+      es: 'Spanish',
+    },
+    languagesSorted: [
+      {
+        value: 'English',
+        label: 'English',
+      },
+      {
+        value: 'Spanish',
+        label: 'Spanish',
+      },
+    ],
+  },
+  loading: false,
+  error: null,
+}))
+
+export { useConfigMock }

--- a/src/tests/utilsTest/render.tsx
+++ b/src/tests/utilsTest/render.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { render as rtlRender, RenderOptions } from '@testing-library/react'
+import { ChakraProvider } from '@chakra-ui/react'
+import { useConfigMock } from './mocks'
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+})
+
+jest.mock('@/hooks/useConfig', () => ({
+  __esModule: true,
+  default: useConfigMock,
+}))
+
+const AllTheProviders: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  return (
+    <React.StrictMode>
+      <ChakraProvider>{children}</ChakraProvider>
+    </React.StrictMode>
+  )
+}
+
+const customRender = (
+  ui: React.ReactElement,
+  options?: Omit<RenderOptions, 'wrapper'>,
+) => rtlRender(ui, { wrapper: AllTheProviders, ...options })
+
+export { customRender }

--- a/src/tests/utilsTest/render.tsx
+++ b/src/tests/utilsTest/render.tsx
@@ -3,6 +3,9 @@ import { render as rtlRender, RenderOptions } from '@testing-library/react'
 import { ChakraProvider } from '@chakra-ui/react'
 import { useConfigMock } from './mocks'
 
+// Solution for avoid -> Error: Uncaught [TypeError: env.window.matchMedia is not a function]
+// Please check https://github.com/chakra-ui/chakra-ui/discussions/6664
+// Please check https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
   value: jest.fn().mockImplementation((query: string) => ({

--- a/src/utils/configureConfig.ts
+++ b/src/utils/configureConfig.ts
@@ -1,0 +1,12 @@
+import { IConfig } from '@/interfaces'
+
+export const configureConfig = (config: IConfig): IConfig => {
+  // Add languagesSorted to condifg object
+  const languagesSorted = Object.keys(config?.languages || {})
+    .map((key) => ({
+      value: key,
+      label: config?.languages[key],
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label))
+  return { ...config, languagesSorted: languagesSorted }
+}

--- a/src/utils/modifyConfig.ts
+++ b/src/utils/modifyConfig.ts
@@ -1,6 +1,6 @@
 import { IConfig } from '@/interfaces'
 
-export const configureConfig = (config: IConfig): IConfig => {
+export const modifyConfig = (config: IConfig): IConfig => {
   // Add languagesSorted to condifg object
   const languagesSorted = Object.keys(config?.languages || {})
     .map((key) => ({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "esModuleInterop": true,
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
Features:

1. Replace language selector for chakra one (allowing filter by typing).
2. Create new attribute of Config for sorted languages.
3. Store the sorted languages in Cache for rendering only first time.
4. Create architecture for component tests (wrappers and mocks).
5. Create unit and component testing for covering this solution.

Problems:
chrakra-react-select is a weird component hard to test (there are not documentation, no examples in stackoverflow and no tests inside of the library 💀). I wasn't able to test it as fully as I had hoped.