### PR TITLE
Pdct 820/make source url field optional & pdct-934/language selector should be optional

### DIFF
--- a/src/components/forms/DocumentForm.tsx
+++ b/src/components/forms/DocumentForm.tsx
@@ -167,7 +167,7 @@ export const DocumentForm = ({
             <FormLabel>Title</FormLabel>
             <Input bg="white" {...register('title')} />
           </FormControl>
-          <FormControl isRequired isInvalid={!!errors.source_url}>
+          <FormControl isInvalid={!!errors.source_url}>
             <FormLabel>Source URL</FormLabel>
             <Input bg="white" {...register('source_url')} />
             <FormErrorMessage role="error">

--- a/src/components/forms/DocumentForm.tsx
+++ b/src/components/forms/DocumentForm.tsx
@@ -63,7 +63,8 @@ export const DocumentForm = ({
     ): IDocumentFormPostModified => {
       return {
         ...data,
-        variant_name: submittedDcumentData.variant_name || null,
+        source_url: data.source_url || null,
+        variant_name: data.variant_name || null,
         user_language_name: data.user_language_name?.label || null,
       }
     }

--- a/src/components/forms/DocumentForm.tsx
+++ b/src/components/forms/DocumentForm.tsx
@@ -63,9 +63,10 @@ export const DocumentForm = ({
     ): IDocumentFormPostModified => {
       return {
         ...data,
-        source_url: data.source_url || null,
-        variant_name: data.variant_name || null,
-        user_language_name: data.user_language_name?.label || null,
+        source_url: submittedDcumentData.source_url || null,
+        variant_name: submittedDcumentData.variant_name || null,
+        user_language_name:
+          submittedDcumentData.user_language_name?.label || null,
       }
     }
 

--- a/src/schemas/documentSchema.ts
+++ b/src/schemas/documentSchema.ts
@@ -7,12 +7,14 @@ export const documentSchema = yup
     role: yup.string().required(),
     type: yup.string().required(),
     title: yup.string().required(),
-    source_url: yup.string().url().optional(),
+    source_url: yup.string().url().defined().strict(true).optional(),
     user_language_name: yup
       .object({
         label: yup.string().required(),
         value: yup.string().required(),
       })
+      .defined()
+      .strict(true)
       .optional(),
   })
   .required()

--- a/src/tests/components/forms/DocumentForm.test.tsx
+++ b/src/tests/components/forms/DocumentForm.test.tsx
@@ -50,7 +50,7 @@ describe('DocumentForm', () => {
     const input = screen.getByRole('textbox', { name: /source url/i })
     const submitButton = screen.getByText('Update Document')
 
-    const newUrl = 'test-no-url'
+    const newUrl = 'test-invalid-url'
     fireEvent.change(input, { target: { value: newUrl } })
     await waitFor(() => {
       expect(input).toHaveValue(newUrl)
@@ -60,6 +60,30 @@ describe('DocumentForm', () => {
     await waitFor(() => {
       const errorMessage = screen.getByRole('error')
       expect(errorMessage).toBeInTheDocument()
+    })
+  })
+
+  it('validate empty document URL', async () => {
+    customRender(
+      <DocumentForm
+        familyId={'test'}
+        onSuccess={onDocumentFormSuccess}
+        document={mockDocument}
+      />,
+    )
+
+    const input = screen.getByRole('textbox', { name: /source url/i })
+    const submitButton = screen.getByText('Update Document')
+
+    const newUrl = ''
+    fireEvent.change(input, { target: { value: newUrl } })
+    await waitFor(() => {
+      expect(input).toHaveValue(newUrl)
+    })
+    fireEvent.submit(submitButton)
+
+    await waitFor(() => {
+      expect(onDocumentFormSuccess).toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
PDCT-820
Driveby PDCT-934
 
- removed is required * from source_url field
- and test for empty doc URL
- update document schema to validate defined values for language selector (driveby) & source URL textboxes
- add logical OR null for source_url field in convertToModified on form submission