### PR TITLE
Pdct 831/family will not get published alert

### DIFF
--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -819,7 +819,14 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
               )}
               {loadedFamily && (
                 <Box>
-                  <Button onClick={() => onAddNewEntityClick('document')} rightIcon={familyDocuments.length === 0 ? <WarningIcon color="red.500" /> : undefined}>
+                  <Button
+                    onClick={() => onAddNewEntityClick('document')}
+                    rightIcon={
+                      familyDocuments.length === 0 ? (
+                        <WarningIcon color="red.500" />
+                      ) : undefined
+                    }
+                  >
                     Add new Document
                   </Button>
                 </Box>
@@ -849,7 +856,14 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
               )}
               {loadedFamily && (
                 <Box>
-                  <Button onClick={() => onAddNewEntityClick('event')} rightIcon={familyEvents.length === 0 ? <WarningIcon color="red.500" /> : undefined}>
+                  <Button
+                    onClick={() => onAddNewEntityClick('event')}
+                    rightIcon={
+                      familyEvents.length === 0 ? (
+                        <WarningIcon color="red.500" />
+                      ) : undefined
+                    }
+                  >
                     Add new Event
                   </Button>
                 </Box>

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -823,7 +823,10 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                     onClick={() => onAddNewEntityClick('document')}
                     rightIcon={
                       familyDocuments.length === 0 ? (
-                        <WarningIcon color="red.500" />
+                        <WarningIcon
+                          color="red.500"
+                          data-test-id="warning-icon-document"
+                        />
                       ) : undefined
                     }
                   >
@@ -860,7 +863,10 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                     onClick={() => onAddNewEntityClick('event')}
                     rightIcon={
                       familyEvents.length === 0 ? (
-                        <WarningIcon color="red.500" />
+                        <WarningIcon
+                          color="red.500"
+                          data-test-id="warning-icon-event"
+                        />
                       ) : undefined
                     }
                   >

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -69,6 +69,7 @@ import { formatDate } from '@/utils/formatDate'
 import { WYSIWYG } from '../form-components/WYSIWYG'
 import { decodeToken } from '@/utils/decodeToken'
 import { chakraStylesSelect } from '@/styles/chakra'
+import { WarningIcon } from '@chakra-ui/icons'
 
 type TMultiSelect = {
   value: string
@@ -818,7 +819,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
               )}
               {loadedFamily && (
                 <Box>
-                  <Button onClick={() => onAddNewEntityClick('document')}>
+                  <Button onClick={() => onAddNewEntityClick('document')} rightIcon={familyDocuments.length === 0 ? <WarningIcon color="red.500" /> : undefined}>
                     Add new Document
                   </Button>
                 </Box>
@@ -848,7 +849,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
               )}
               {loadedFamily && (
                 <Box>
-                  <Button onClick={() => onAddNewEntityClick('event')}>
+                  <Button onClick={() => onAddNewEntityClick('event')} rightIcon={familyEvents.length === 0 ? <WarningIcon color="red.500" /> : undefined}>
                     Add new Event
                   </Button>
                 </Box>

--- a/src/components/lists/FamilyList.tsx
+++ b/src/components/lists/FamilyList.tsx
@@ -23,7 +23,7 @@ import { GoPencil } from 'react-icons/go'
 
 import { DeleteButton } from '../buttons/Delete'
 import { sortBy } from '@/utils/sortBy'
-import { ArrowDownIcon, ArrowUpIcon, ArrowUpDownIcon } from '@chakra-ui/icons'
+import { ArrowDownIcon, ArrowUpIcon, ArrowUpDownIcon, WarningIcon } from '@chakra-ui/icons'
 import { getStatusColour } from '@/utils/getStatusColour'
 import { getStatusAlias } from '@/utils/getStatusAlias'
 import { ApiError } from '../feedback/ApiError'
@@ -218,7 +218,14 @@ export default function FamilyList() {
                   family.import_id === familyError ? 'red.500' : 'inherit'
                 }
               >
-                <Td>{family.title}</Td>
+                <Td>
+                  <Flex gap="2" alignItems="center">
+                    {(!family.documents?.length && !family.events?.length) && (
+                      <WarningIcon color="red.500" />
+                    )}
+                    {family.title}
+                  </Flex>
+                </Td>
                 <Td>{family.category}</Td>
                 <Td>{family.geography}</Td>
                 <Td>{formatDate(family.published_date)}</Td>

--- a/src/components/lists/FamilyList.tsx
+++ b/src/components/lists/FamilyList.tsx
@@ -216,6 +216,7 @@ export default function FamilyList() {
             {filteredItems?.map((family) => (
               <Tr
                 key={family.import_id}
+                data-testid={`family-row-${family.import_id}`}
                 borderLeft={
                   family.import_id === familyError ? '2px' : 'inherit'
                 }
@@ -226,7 +227,7 @@ export default function FamilyList() {
                 <Td>
                   <Flex gap="2" alignItems="center">
                     {!family.documents?.length && !family.events?.length && (
-                      <WarningIcon color="red.500" />
+                      <WarningIcon color="red.500" data-testid="warning-icon" />
                     )}
                     {family.title}
                   </Flex>

--- a/src/components/lists/FamilyList.tsx
+++ b/src/components/lists/FamilyList.tsx
@@ -23,7 +23,12 @@ import { GoPencil } from 'react-icons/go'
 
 import { DeleteButton } from '../buttons/Delete'
 import { sortBy } from '@/utils/sortBy'
-import { ArrowDownIcon, ArrowUpIcon, ArrowUpDownIcon, WarningIcon } from '@chakra-ui/icons'
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  ArrowUpDownIcon,
+  WarningIcon,
+} from '@chakra-ui/icons'
 import { getStatusColour } from '@/utils/getStatusColour'
 import { getStatusAlias } from '@/utils/getStatusAlias'
 import { ApiError } from '../feedback/ApiError'
@@ -220,7 +225,7 @@ export default function FamilyList() {
               >
                 <Td>
                   <Flex gap="2" alignItems="center">
-                    {(!family.documents?.length && !family.events?.length) && (
+                    {!family.documents?.length && !family.events?.length && (
                       <WarningIcon color="red.500" />
                     )}
                     {family.title}

--- a/src/components/lists/FamilyList.tsx
+++ b/src/components/lists/FamilyList.tsx
@@ -226,7 +226,7 @@ export default function FamilyList() {
               >
                 <Td>
                   <Flex gap="2" alignItems="center">
-                    {!family.documents?.length && !family.events?.length && (
+                    {(!family.documents?.length || !family.events?.length) && (
                       <WarningIcon color="red.500" data-testid="warning-icon" />
                     )}
                     {family.title}

--- a/src/tests/components/forms/FamilyForm.test.tsx
+++ b/src/tests/components/forms/FamilyForm.test.tsx
@@ -118,6 +118,40 @@ describe('FamilyList', () => {
   })
 })
 
+describe('FamilyForm Icons Visibility', () => {
+  it('displays warning icon next to "Add new document" button when there are no documents', async () => {
+    const familyWithoutDocuments = { ...mockFamiliesData[0], documents: [] }
+    localStorage.setItem('token', 'token')
+    const { getByTestId } = renderComponent(familyWithoutDocuments)
+    await flushPromises()
+
+    const warningIconDocument = getByTestId('warning-icon-document')
+    expect(warningIconDocument).toBeInTheDocument()
+  })
+
+  it('displays warning icon next to "Add new event" button when there are no events', async () => {
+    const familyWithoutEvents = { ...mockFamiliesData[0], events: [] }
+    localStorage.setItem('token', 'token')
+    const { getByTestId } = renderComponent(familyWithoutEvents)
+    await flushPromises()
+
+    const warningIconEvent = getByTestId('warning-icon-event')
+    expect(warningIconEvent).toBeInTheDocument()
+  })
+
+  it('does not display warning icon next to "Add new document/events" button when there are documents/events', async () => {
+    const family = mockFamiliesData[0]
+    localStorage.setItem('token', 'token')
+    renderComponent(family)
+    await flushPromises()
+
+    const warningIconEvent = screen.queryByTestId('warning-icon-event')
+    const warningIconDocument = screen.queryByTestId('warning-icon-document')
+    expect(warningIconEvent).not.toBeInTheDocument()
+    expect(warningIconDocument).not.toBeInTheDocument()
+  })
+})
+
 // TEST: isDirty & external navigation & internal navigation
 
 // TET: not isDirty & external navigation & internal navigation

--- a/src/tests/components/lists/FamilyList.test.tsx
+++ b/src/tests/components/lists/FamilyList.test.tsx
@@ -84,26 +84,31 @@ describe('FamilyList', () => {
   })
 
   it('shows a warning icon only for families without documents or events', async () => {
-    const familyIdWithDocumentsWithoutEvents = mockFamiliesData[4].import_id
-    const familyIdWithoutDocumentsOrEvents = mockFamiliesData[2].import_id
-    const familyIdWithDocumentsOrEvents = mockFamiliesData[0].import_id
+    const familyIdWithoutDocumentsAndEvents = mockFamiliesData[2].import_id
+    const familyIdWithoutDocuments = mockFamiliesData[3].import_id
+    const familyIdWithoutEvents = mockFamiliesData[4].import_id
+    const familyIdWithDocumentsAndEvents = mockFamiliesData[0].import_id
     await waitFor(() => {
-      const familyRowWithout = within(
-        screen.getByTestId(`family-row-${familyIdWithoutDocumentsOrEvents}`),
+      const familyRowWithoutDocumentsAndEvents = within(
+        screen.getByTestId(`family-row-${familyIdWithoutDocumentsAndEvents}`),
       )
-      const familyRowWithout2 = within(
-        screen.getByTestId(`family-row-${familyIdWithDocumentsWithoutEvents}`),
+      const familyRowWithoutDocuments = within(
+        screen.getByTestId(`family-row-${familyIdWithoutDocuments}`),
       )
-      const familyRowWith = within(
-        screen.getByTestId(`family-row-${familyIdWithDocumentsOrEvents}`),
+      const familyRowWithoutEvents = within(
+        screen.getByTestId(`family-row-${familyIdWithoutEvents}`),
+      )
+      const familyRowWithDocumentsAndEvents = within(
+        screen.getByTestId(`family-row-${familyIdWithDocumentsAndEvents}`),
       )
 
-      expect(familyRowWithout.queryByTestId('warning-icon')).toBeInTheDocument()
+      expect(familyRowWithoutDocumentsAndEvents.queryByTestId('warning-icon')).toBeInTheDocument()
+      expect(familyRowWithoutDocuments.queryByTestId('warning-icon')).toBeInTheDocument()
       expect(
-        familyRowWithout2.queryByTestId('warning-icon'),
+        familyRowWithoutEvents.queryByTestId('warning-icon'),
       ).toBeInTheDocument()
       expect(
-        familyRowWith.queryByTestId('warning-icon'),
+        familyRowWithDocumentsAndEvents.queryByTestId('warning-icon'),
       ).not.toBeInTheDocument()
     })
   })

--- a/src/tests/components/lists/FamilyList.test.tsx
+++ b/src/tests/components/lists/FamilyList.test.tsx
@@ -17,39 +17,42 @@ jest.mock('react-router-dom', (): unknown => ({
   }),
 }))
 
+const UNFCCCFamily = mockFamiliesData[0]
+const mockCCLWFamily = mockFamiliesData[1]
+
 describe('FamilyList', () => {
   beforeEach(async () => {
     customRender(<FamilyList />)
     await waitFor(() => {
-      expect(screen.getByText(mockFamiliesData[0].title)).toBeInTheDocument()
+      expect(screen.getByText(UNFCCCFamily.title)).toBeInTheDocument()
     })
   })
 
   it('renders without crashing', () => {
     // Verify mock family properties are rendered there
-    expect(screen.queryAllByText(mockFamiliesData[0].title)).not.toHaveLength(0)
+    expect(screen.queryAllByText(UNFCCCFamily.title)).not.toHaveLength(0)
     expect(
-      screen.queryAllByText(mockFamiliesData[0].category),
+      screen.queryAllByText(UNFCCCFamily.category),
     ).not.toHaveLength(0)
     expect(
-      screen.queryAllByText(mockFamiliesData[0].geography),
+      screen.queryAllByText(UNFCCCFamily.geography),
     ).not.toHaveLength(0)
     expect(
-      screen.queryAllByText(mockFamiliesData[0].published_date),
+      screen.queryAllByText(UNFCCCFamily.published_date),
     ).not.toHaveLength(0)
     expect(
-      screen.queryAllByText(mockFamiliesData[0].last_updated_date),
+      screen.queryAllByText(UNFCCCFamily.last_updated_date),
     ).not.toHaveLength(0)
-    expect(screen.queryAllByText(mockFamiliesData[0].created)).not.toHaveLength(
+    expect(screen.queryAllByText(UNFCCCFamily.created)).not.toHaveLength(
       0,
     )
     expect(
-      screen.queryAllByText(mockFamiliesData[0].last_modified),
+      screen.queryAllByText(UNFCCCFamily.last_modified),
     ).not.toHaveLength(0)
   })
 
   it('sorts families by title when title header is clicked', async () => {
-    expect(screen.getByText(mockFamiliesData[0].title)).toBeInTheDocument()
+    expect(screen.getByText(UNFCCCFamily.title)).toBeInTheDocument()
     const titleHeader = screen.getByText('Title')
 
     // Sorted
@@ -58,10 +61,10 @@ describe('FamilyList', () => {
       const allFamilies = screen.getAllByText(/Family/)
 
       const indexFamilyOne = allFamilies.findIndex(
-        (element) => element.textContent === mockFamiliesData[1].title,
+        (element) => element.textContent === mockCCLWFamily.title,
       )
       const indexFamilyTwo = allFamilies.findIndex(
-        (element) => element.textContent === mockFamiliesData[0].title,
+        (element) => element.textContent === UNFCCCFamily.title,
       )
 
       expect(indexFamilyOne).toBeLessThan(indexFamilyTwo)
@@ -73,10 +76,10 @@ describe('FamilyList', () => {
       const allFamilies = screen.getAllByText(/Family/)
 
       const indexFamilyOne = allFamilies.findIndex(
-        (element) => element.textContent === mockFamiliesData[1].title,
+        (element) => element.textContent === mockCCLWFamily.title,
       )
       const indexFamilyTwo = allFamilies.findIndex(
-        (element) => element.textContent === mockFamiliesData[0].title,
+        (element) => element.textContent === UNFCCCFamily.title,
       )
 
       expect(indexFamilyOne).toBeGreaterThan(indexFamilyTwo)
@@ -87,7 +90,7 @@ describe('FamilyList', () => {
     const familyIdWithoutDocumentsAndEvents = mockFamiliesData[2].import_id
     const familyIdWithoutDocuments = mockFamiliesData[3].import_id
     const familyIdWithoutEvents = mockFamiliesData[4].import_id
-    const familyIdWithDocumentsAndEvents = mockFamiliesData[0].import_id
+    const familyIdWithDocumentsAndEvents = UNFCCCFamily.import_id
     await waitFor(() => {
       const familyRowWithoutDocumentsAndEvents = within(
         screen.getByTestId(`family-row-${familyIdWithoutDocumentsAndEvents}`),

--- a/src/tests/components/lists/FamilyList.test.tsx
+++ b/src/tests/components/lists/FamilyList.test.tsx
@@ -3,9 +3,7 @@ import { fireEvent, screen, waitFor, within } from '@testing-library/react'
 import '@testing-library/jest-dom'
 
 import FamilyList from '@/components/lists/FamilyList'
-import {
-  mockFamiliesData,
-} from '@/tests/utilsTest/mocks'
+import { mockFamiliesData } from '@/tests/utilsTest/mocks'
 
 jest.mock('@/api/Families', () => ({
   getFamilies: jest.fn(),
@@ -29,13 +27,25 @@ describe('FamilyList', () => {
 
   it('renders without crashing', () => {
     // Verify mock family properties are rendered there
-    expect(screen.queryAllByText(mockFamiliesData[0].title)).not.toHaveLength(0);
-    expect(screen.queryAllByText(mockFamiliesData[0].category)).not.toHaveLength(0);
-    expect(screen.queryAllByText(mockFamiliesData[0].geography)).not.toHaveLength(0);
-    expect(screen.queryAllByText(mockFamiliesData[0].published_date)).not.toHaveLength(0);
-    expect(screen.queryAllByText(mockFamiliesData[0].last_updated_date)).not.toHaveLength(0);
-    expect(screen.queryAllByText(mockFamiliesData[0].created)).not.toHaveLength(0);
-    expect(screen.queryAllByText(mockFamiliesData[0].last_modified)).not.toHaveLength(0);
+    expect(screen.queryAllByText(mockFamiliesData[0].title)).not.toHaveLength(0)
+    expect(
+      screen.queryAllByText(mockFamiliesData[0].category),
+    ).not.toHaveLength(0)
+    expect(
+      screen.queryAllByText(mockFamiliesData[0].geography),
+    ).not.toHaveLength(0)
+    expect(
+      screen.queryAllByText(mockFamiliesData[0].published_date),
+    ).not.toHaveLength(0)
+    expect(
+      screen.queryAllByText(mockFamiliesData[0].last_updated_date),
+    ).not.toHaveLength(0)
+    expect(screen.queryAllByText(mockFamiliesData[0].created)).not.toHaveLength(
+      0,
+    )
+    expect(
+      screen.queryAllByText(mockFamiliesData[0].last_modified),
+    ).not.toHaveLength(0)
   })
 
   it('sorts families by title when title header is clicked', async () => {
@@ -48,7 +58,7 @@ describe('FamilyList', () => {
       const allFamilies = screen.getAllByText(/Family/)
 
       const indexFamilyOne = allFamilies.findIndex(
-        (element) => element.textContent === mockFamiliesData[1].title
+        (element) => element.textContent === mockFamiliesData[1].title,
       )
       const indexFamilyTwo = allFamilies.findIndex(
         (element) => element.textContent === mockFamiliesData[0].title,

--- a/src/tests/components/lists/FamilyList.test.tsx
+++ b/src/tests/components/lists/FamilyList.test.tsx
@@ -102,8 +102,12 @@ describe('FamilyList', () => {
         screen.getByTestId(`family-row-${familyIdWithDocumentsAndEvents}`),
       )
 
-      expect(familyRowWithoutDocumentsAndEvents.queryByTestId('warning-icon')).toBeInTheDocument()
-      expect(familyRowWithoutDocuments.queryByTestId('warning-icon')).toBeInTheDocument()
+      expect(
+        familyRowWithoutDocumentsAndEvents.queryByTestId('warning-icon'),
+      ).toBeInTheDocument()
+      expect(
+        familyRowWithoutDocuments.queryByTestId('warning-icon'),
+      ).toBeInTheDocument()
       expect(
         familyRowWithoutEvents.queryByTestId('warning-icon'),
       ).toBeInTheDocument()

--- a/src/tests/components/lists/FamilyList.test.tsx
+++ b/src/tests/components/lists/FamilyList.test.tsx
@@ -3,40 +3,14 @@ import { fireEvent, screen, waitFor, within } from '@testing-library/react'
 import '@testing-library/jest-dom'
 
 import FamilyList from '@/components/lists/FamilyList'
+import {
+  mockFamiliesData,
+} from '@/tests/utilsTest/mocks'
 
 jest.mock('@/api/Families', () => ({
   getFamilies: jest.fn(),
   deleteFamily: jest.fn(),
 }))
-
-const mockFamiliesData = [
-  {
-    import_id: '1',
-    title: 'Family One',
-    category: 'Category One',
-    geography: 'Geography One',
-    published_date: '1/1/2021',
-    last_updated_date: '2/1/2021',
-    last_modified: '3/1/2021',
-    created: '4/1/2021',
-    status: 'active',
-    documents: [],
-    events: [],
-  },
-  {
-    import_id: '2',
-    title: 'Family Two',
-    category: 'Category Two',
-    geography: 'Geography Two',
-    published_date: '1/2/2021',
-    last_updated_date: '2/2/2021',
-    last_modified: '3/2/2021',
-    created: '4/2/2021',
-    status: 'active',
-    documents: ['doc1'],
-    events: ['event1'],
-  },
-]
 
 jest.mock('react-router-dom', (): unknown => ({
   ...jest.requireActual('react-router-dom'),
@@ -49,23 +23,23 @@ describe('FamilyList', () => {
   beforeEach(async () => {
     customRender(<FamilyList />)
     await waitFor(() => {
-      expect(screen.getByText('Family One')).toBeInTheDocument()
+      expect(screen.getByText(mockFamiliesData[0].title)).toBeInTheDocument()
     })
   })
 
   it('renders without crashing', () => {
     // Verify mock family properties are rendered there
-    expect(screen.getByText('Family One')).toBeInTheDocument()
-    expect(screen.getByText('Category One')).toBeInTheDocument()
-    expect(screen.getByText('Geography One')).toBeInTheDocument()
-    expect(screen.getByText('1/1/2021')).toBeInTheDocument()
-    expect(screen.getByText('2/1/2021')).toBeInTheDocument()
-    expect(screen.getByText('3/1/2021')).toBeInTheDocument()
-    expect(screen.getByText('4/1/2021')).toBeInTheDocument()
+    expect(screen.queryAllByText(mockFamiliesData[0].title)).not.toHaveLength(0);
+    expect(screen.queryAllByText(mockFamiliesData[0].category)).not.toHaveLength(0);
+    expect(screen.queryAllByText(mockFamiliesData[0].geography)).not.toHaveLength(0);
+    expect(screen.queryAllByText(mockFamiliesData[0].published_date)).not.toHaveLength(0);
+    expect(screen.queryAllByText(mockFamiliesData[0].last_updated_date)).not.toHaveLength(0);
+    expect(screen.queryAllByText(mockFamiliesData[0].created)).not.toHaveLength(0);
+    expect(screen.queryAllByText(mockFamiliesData[0].last_modified)).not.toHaveLength(0);
   })
 
   it('sorts families by title when title header is clicked', async () => {
-    expect(screen.getByText('Family One')).toBeInTheDocument()
+    expect(screen.getByText(mockFamiliesData[0].title)).toBeInTheDocument()
     const titleHeader = screen.getByText('Title')
 
     // Sorted
@@ -74,10 +48,10 @@ describe('FamilyList', () => {
       const allFamilies = screen.getAllByText(/Family/)
 
       const indexFamilyOne = allFamilies.findIndex(
-        (element) => element.textContent === 'Family One',
+        (element) => element.textContent === mockFamiliesData[1].title
       )
       const indexFamilyTwo = allFamilies.findIndex(
-        (element) => element.textContent === 'Family Two',
+        (element) => element.textContent === mockFamiliesData[0].title,
       )
 
       expect(indexFamilyOne).toBeLessThan(indexFamilyTwo)
@@ -89,10 +63,10 @@ describe('FamilyList', () => {
       const allFamilies = screen.getAllByText(/Family/)
 
       const indexFamilyOne = allFamilies.findIndex(
-        (element) => element.textContent === 'Family One',
+        (element) => element.textContent === mockFamiliesData[1].title,
       )
       const indexFamilyTwo = allFamilies.findIndex(
-        (element) => element.textContent === 'Family Two',
+        (element) => element.textContent === mockFamiliesData[0].title,
       )
 
       expect(indexFamilyOne).toBeGreaterThan(indexFamilyTwo)
@@ -100,8 +74,8 @@ describe('FamilyList', () => {
   })
 
   it('shows a warning icon only for families without documents or events', async () => {
-    const familyIdWithoutDocumentsOrEvents = '1'
-    const familyIdWithDocumentsOrEvents = '2'
+    const familyIdWithoutDocumentsOrEvents = mockFamiliesData[2].import_id
+    const familyIdWithDocumentsOrEvents = mockFamiliesData[0].import_id
     await waitFor(() => {
       const familyRowWithout = within(
         screen.getByTestId(`family-row-${familyIdWithoutDocumentsOrEvents}`),

--- a/src/tests/components/lists/FamilyList.test.tsx
+++ b/src/tests/components/lists/FamilyList.test.tsx
@@ -111,7 +111,9 @@ describe('FamilyList', () => {
       )
 
       expect(familyRowWithout.queryByTestId('warning-icon')).toBeInTheDocument()
-      expect(familyRowWith.queryByTestId('warning-icon')).not.toBeInTheDocument()
-  })
+      expect(
+        familyRowWith.queryByTestId('warning-icon'),
+      ).not.toBeInTheDocument()
+    })
   })
 })

--- a/src/tests/components/lists/FamilyList.test.tsx
+++ b/src/tests/components/lists/FamilyList.test.tsx
@@ -31,24 +31,18 @@ describe('FamilyList', () => {
   it('renders without crashing', () => {
     // Verify mock family properties are rendered there
     expect(screen.queryAllByText(UNFCCCFamily.title)).not.toHaveLength(0)
-    expect(
-      screen.queryAllByText(UNFCCCFamily.category),
-    ).not.toHaveLength(0)
-    expect(
-      screen.queryAllByText(UNFCCCFamily.geography),
-    ).not.toHaveLength(0)
-    expect(
-      screen.queryAllByText(UNFCCCFamily.published_date),
-    ).not.toHaveLength(0)
-    expect(
-      screen.queryAllByText(UNFCCCFamily.last_updated_date),
-    ).not.toHaveLength(0)
-    expect(screen.queryAllByText(UNFCCCFamily.created)).not.toHaveLength(
+    expect(screen.queryAllByText(UNFCCCFamily.category)).not.toHaveLength(0)
+    expect(screen.queryAllByText(UNFCCCFamily.geography)).not.toHaveLength(0)
+    expect(screen.queryAllByText(UNFCCCFamily.published_date)).not.toHaveLength(
       0,
     )
     expect(
-      screen.queryAllByText(UNFCCCFamily.last_modified),
+      screen.queryAllByText(UNFCCCFamily.last_updated_date),
     ).not.toHaveLength(0)
+    expect(screen.queryAllByText(UNFCCCFamily.created)).not.toHaveLength(0)
+    expect(screen.queryAllByText(UNFCCCFamily.last_modified)).not.toHaveLength(
+      0,
+    )
   })
 
   it('sorts families by title when title header is clicked', async () => {

--- a/src/tests/components/lists/FamilyList.test.tsx
+++ b/src/tests/components/lists/FamilyList.test.tsx
@@ -84,17 +84,24 @@ describe('FamilyList', () => {
   })
 
   it('shows a warning icon only for families without documents or events', async () => {
+    const familyIdWithDocumentsWithoutEvents = mockFamiliesData[4].import_id
     const familyIdWithoutDocumentsOrEvents = mockFamiliesData[2].import_id
     const familyIdWithDocumentsOrEvents = mockFamiliesData[0].import_id
     await waitFor(() => {
       const familyRowWithout = within(
         screen.getByTestId(`family-row-${familyIdWithoutDocumentsOrEvents}`),
       )
+      const familyRowWithout2 = within(
+        screen.getByTestId(`family-row-${familyIdWithDocumentsWithoutEvents}`),
+      )
       const familyRowWith = within(
         screen.getByTestId(`family-row-${familyIdWithDocumentsOrEvents}`),
       )
 
       expect(familyRowWithout.queryByTestId('warning-icon')).toBeInTheDocument()
+      expect(
+        familyRowWithout2.queryByTestId('warning-icon'),
+      ).toBeInTheDocument()
       expect(
         familyRowWith.queryByTestId('warning-icon'),
       ).not.toBeInTheDocument()

--- a/src/tests/components/lists/FamilyList.test.tsx
+++ b/src/tests/components/lists/FamilyList.test.tsx
@@ -1,5 +1,5 @@
 import { customRender } from '@/tests/utilsTest/render'
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor, within } from '@testing-library/react'
 import '@testing-library/jest-dom'
 
 import FamilyList from '@/components/lists/FamilyList'
@@ -20,6 +20,8 @@ const mockFamiliesData = [
     last_modified: '3/1/2021',
     created: '4/1/2021',
     status: 'active',
+    documents: [],
+    events: [],
   },
   {
     import_id: '2',
@@ -31,6 +33,8 @@ const mockFamiliesData = [
     last_modified: '3/2/2021',
     created: '4/2/2021',
     status: 'active',
+    documents: ['doc1'],
+    events: ['event1'],
   },
 ]
 
@@ -93,5 +97,21 @@ describe('FamilyList', () => {
 
       expect(indexFamilyOne).toBeGreaterThan(indexFamilyTwo)
     })
+  })
+
+  it('shows a warning icon only for families without documents or events', async () => {
+    const familyIdWithoutDocumentsOrEvents = '1'
+    const familyIdWithDocumentsOrEvents = '2'
+    await waitFor(() => {
+      const familyRowWithout = within(
+        screen.getByTestId(`family-row-${familyIdWithoutDocumentsOrEvents}`),
+      )
+      const familyRowWith = within(
+        screen.getByTestId(`family-row-${familyIdWithDocumentsOrEvents}`),
+      )
+
+      expect(familyRowWithout.queryByTestId('warning-icon')).toBeInTheDocument()
+      expect(familyRowWith.queryByTestId('warning-icon')).not.toBeInTheDocument()
+  })
   })
 })

--- a/src/tests/utilsTest/mocks.tsx
+++ b/src/tests/utilsTest/mocks.tsx
@@ -126,6 +126,39 @@ const mockCCLWFamily: ICCLWFamily = {
   },
 }
 
+const mockUNFCCCFamilyNoDocumentsNoEvents: IUNFCCCFamily = {
+  ...mockUNFCCCFamily,
+  import_id: 'UNFCCC.family.3.0',
+  title: 'UNFCCC Family Three',
+  summary: 'Summary for UNFCCC Family Three with no documents and no events',
+  documents: [], // Sin documentos
+  events: [], // Sin eventos
+  created: '5/1/2021',
+  last_modified: '6/1/2021',
+}
+
+const mockCCLWFamilyNoDocuments: ICCLWFamily = {
+  ...mockCCLWFamily,
+  import_id: 'CCLW.family.4.0',
+  title: 'CCLW Family Four',
+  summary: 'Summary for CCLW Family Four with no documents',
+  documents: [], // Sin documentos
+  created: '5/2/2021',
+  last_modified: '6/2/2021',
+}
+
+const mockCCLWFamilyNoEvents: ICCLWFamily = {
+  ...mockCCLWFamily,
+  import_id: 'CCLW.family.5.0',
+  title: 'CCLW Family Five',
+  summary: 'Summary for CCLW Family Five with no events',
+  events: [], // Sin eventos
+  created: '7/2/2021',
+  last_modified: '8/2/2021',
+}
+
+// Extiende mockFamiliesData para incluir los nuevos casos
+
 const mockDocument = {
   import_id: 'CCLW.doc.1.1',
   family_import_id: 'CCLW.family.2.0',
@@ -144,6 +177,12 @@ const mockDocument = {
 }
 
 // Exports
-export const mockFamiliesData = [mockUNFCCCFamily, mockCCLWFamily]
+export const mockFamiliesData = [
+  mockUNFCCCFamily,
+  mockCCLWFamily,
+  mockUNFCCCFamilyNoDocumentsNoEvents,
+  mockCCLWFamilyNoDocuments,
+  mockCCLWFamilyNoEvents,
+]
 export { mockConfig as configMock }
 export { mockDocument }

--- a/src/tests/utilsTest/mocks.tsx
+++ b/src/tests/utilsTest/mocks.tsx
@@ -157,8 +157,6 @@ const mockCCLWFamilyNoEvents: ICCLWFamily = {
   last_modified: '8/2/2021',
 }
 
-// Extiende mockFamiliesData para incluir los nuevos casos
-
 const mockDocument = {
   import_id: 'CCLW.doc.1.1',
   family_import_id: 'CCLW.family.2.0',


### PR DESCRIPTION
# What's changed

- Alert icon for buttons in FamilyForm if there is not Documents or Events.
<img width="825" alt="image" src="https://github.com/climatepolicyradar/navigator-admin-frontend/assets/8972362/44cf23d0-1f50-4e12-8c23-e141b7debbe4">

- Alert icon in FamilyList if there is Documents or Events empty (NO Documents AND NO Events)

<img width="611" alt="image" src="https://github.com/climatepolicyradar/navigator-admin-frontend/assets/8972362/5f07f988-88d7-41c4-8026-97f3f45d5c63">


## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Patch
- [x] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
