### PR TITLE
PDCT-968/bug_create_family_trigger_modal_always

### DIFF
--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -105,7 +105,7 @@ const getCollection = (collectionId: string, collections: ICollection[]) => {
 
 export const FamilyForm = ({ family: loadedFamily }: TProps) => {
   const [isLeavingModalOpen, setIsLeavingModalOpen] = useState(false)
-  const [isFormSubmitting, setIsFormSubmitting] = useState(false);
+  const [isFormSubmitting, setIsFormSubmitting] = useState(false)
   const { isOpen, onOpen, onClose } = useDisclosure()
   const navigate = useNavigate()
   const { config, error: configError, loading: configLoading } = useConfig()
@@ -220,8 +220,8 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
         })
       })
       .finally(() => {
-        setIsFormSubmitting(false);
-      });
+        setIsFormSubmitting(false)
+      })
   } // end handleFormSubmission
 
   const onSubmit: SubmitHandler<IFamilyForm> = (data) =>
@@ -391,7 +391,9 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
   // Internal and external navigation blocker for unsaved changes
   const blocker = useBlocker(
     ({ currentLocation, nextLocation }) =>
-    !isFormSubmitting && Object.keys(dirtyFields).length > 0 && currentLocation.pathname !== nextLocation.pathname,
+      !isFormSubmitting &&
+      Object.keys(dirtyFields).length > 0 &&
+      currentLocation.pathname !== nextLocation.pathname,
   )
 
   const handleBeforeUnload = useCallback(


### PR DESCRIPTION
# What's changed

Fix the use of the blocker

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
