### PR TITLE
Pdct 851/fail the auto tagging build during a pr if no semver boxes ticked

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,7 @@
 Please select the option below that is most relevant from the list below. This
 will be used to generate the next tag version name during auto-tagging.
 
+- [ ] Skip auto-tagging
 - [ ] Patch
 - [ ] Minor version
 - [ ] Major version

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -110,7 +110,7 @@ jobs:
       - code-quality
       - test
     if: ${{ startsWith(github.ref, 'refs/tags') }}
-    uses: climatepolicyradar/reusable-workflows/.github/workflows/semver.yml@main
+    uses: climatepolicyradar/reusable-workflows/.github/workflows/semver.yml@v3
     secrets: inherit
     with:
       repo-name: navigator-admin-frontend
@@ -118,7 +118,7 @@ jobs:
 
   tag:
     needs: build
-    uses: climatepolicyradar/reusable-workflows/.github/workflows/tag.yml@main
+    uses: climatepolicyradar/reusable-workflows/.github/workflows/tag.yml@v3
     with:
       repo-name: navigator-admin-frontend
       semver-tag: main-${GITHUB_SHA::8}
@@ -129,6 +129,6 @@ jobs:
 
   release:
     needs: tag
-    uses: climatepolicyradar/reusable-workflows/.github/workflows/release.yml@main
+    uses: climatepolicyradar/reusable-workflows/.github/workflows/release.yml@v3
     with:
       new_tag: ${{ needs.tag.outputs.new_tag }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -77,7 +77,10 @@ jobs:
         run: yarn test
 
   build:
-    if: ${{ ! startsWith(github.ref, 'refs/tags') }}
+    if: |
+      always() &&
+      (needs.code-quality.result == 'success' && needs.test.result == 'success') &&
+      ! startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     needs:
       - code-quality
@@ -125,10 +128,7 @@ jobs:
           fi
 
   manual-semver:
-    needs:
-      - code-quality
-      - test
-    if: ${{ startsWith(github.ref, 'refs/tags') }}
+    if: ${{ always() && startsWith(github.ref, 'refs/tags') }}
     uses: climatepolicyradar/reusable-workflows/.github/workflows/semver.yml@v3
     secrets: inherit
     with:
@@ -136,6 +136,7 @@ jobs:
       semver-tag: main-${GITHUB_SHA::8}
 
   tag:
+    if: ${{ always() && (needs.build.result == 'success')}}
     needs: build
     uses: climatepolicyradar/reusable-workflows/.github/workflows/tag.yml@v3
     with:
@@ -147,6 +148,7 @@ jobs:
       DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
 
   release:
+    if: ${{ always() && (needs.tag.result == 'success' && needs.tag.outputs.new_tag != 'Skip')}}
     needs: tag
     uses: climatepolicyradar/reusable-workflows/.github/workflows/release.yml@v3
     with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -6,11 +6,25 @@ on:
     branches:
       - main
   pull_request:
+    # By default, a workflow only runs when a pull_request event's activity type is opened,
+    # synchronize, or reopened.
+    types: [opened, synchronize, reopened, edited]
     branches:
       - main
 
 jobs:
+  check-auto-tagging-will-work:
+    if: |
+      github.event_name == 'pull_request' &&
+      (! startsWith(github.ref, 'refs/tags') && ! startsWith(github.ref, 'refs/heads/main'))
+    uses: climatepolicyradar/reusable-workflows/.github/workflows/check-auto-tagging-will-work.yml@v3
+
   code-quality:
+    if: |
+      always() &&
+      (needs.check-auto-tagging-will-work.result == 'skipped' || needs.check-auto-tagging-will-work.result == 'success')
+    needs:
+      - check-auto-tagging-will-work
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -38,6 +52,11 @@ jobs:
         run: yarn lint
 
   test:
+    if: |
+      always() &&
+      (needs.check-auto-tagging-will-work.result == 'skipped' || needs.check-auto-tagging-will-work.result == 'success')
+    needs:
+      - check-auto-tagging-will-work
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
# What's changed

Fixed auto tag pipeline for manual semver

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
