### PR TITLE
Use always() and ! cancelled() to avoid uncancellable workflows

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -21,7 +21,7 @@ jobs:
 
   code-quality:
     if: |
-      always() &&
+      ! cancelled() && always() &&
       (needs.check-auto-tagging-will-work.result == 'skipped' || needs.check-auto-tagging-will-work.result == 'success')
     needs:
       - check-auto-tagging-will-work
@@ -53,7 +53,7 @@ jobs:
 
   test:
     if: |
-      always() &&
+      ! cancelled() && always() &&
       (needs.check-auto-tagging-will-work.result == 'skipped' || needs.check-auto-tagging-will-work.result == 'success')
     needs:
       - check-auto-tagging-will-work
@@ -78,7 +78,7 @@ jobs:
 
   build:
     if: |
-      always() &&
+      ! cancelled() && always() &&
       (needs.code-quality.result == 'success' && needs.test.result == 'success') &&
       ! startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
@@ -128,7 +128,7 @@ jobs:
           fi
 
   manual-semver:
-    if: ${{ always() && startsWith(github.ref, 'refs/tags') }}
+    if: ${{ ! cancelled() && always() && startsWith(github.ref, 'refs/tags') }}
     uses: climatepolicyradar/reusable-workflows/.github/workflows/semver.yml@v3
     secrets: inherit
     with:
@@ -136,7 +136,7 @@ jobs:
       semver-tag: main-${GITHUB_SHA::8}
 
   tag:
-    if: ${{ always() && (needs.build.result == 'success')}}
+    if: ${{ ! cancelled() && always() && (needs.build.result == 'success')}}
     needs: build
     uses: climatepolicyradar/reusable-workflows/.github/workflows/tag.yml@v3
     with:
@@ -148,7 +148,7 @@ jobs:
       DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
 
   release:
-    if: ${{ always() && (needs.tag.result == 'success' && needs.tag.outputs.new_tag != 'Skip')}}
+    if: ${{ ! cancelled() && always() && (needs.tag.result == 'success' && needs.tag.outputs.new_tag != 'Skip')}}
     needs: tag
     uses: climatepolicyradar/reusable-workflows/.github/workflows/release.yml@v3
     with:


### PR DESCRIPTION
# What's changed

Use always() and ! cancelled() to avoid uncancellable workflows

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
