### PR TITLE
Show corpus_id and corpus_type as read only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ dist-ssr
 
 # NPM lock file (we are using yarn)
 package-lock.json
+.prettierrc

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -488,6 +488,26 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                   />
                 </FormControl>
               )}
+              {loadedFamily && (
+                <FormControl isRequired isReadOnly isDisabled>
+                  <FormLabel>Corpus ID</FormLabel>
+                  <Input
+                    data-test-id='corpus-id'
+                    bg='white'
+                    value={loadedFamily?.corpus_id}
+                  />
+                </FormControl>
+              )}
+              {loadedFamily && (
+                <FormControl isRequired isReadOnly isDisabled>
+                  <FormLabel>Corpus Type</FormLabel>
+                  <Input
+                    data-test-id='corpus-type'
+                    bg='white'
+                    value={loadedFamily?.corpus_type}
+                  />
+                </FormControl>
+              )}
               <FormControl isRequired>
                 <FormLabel>Title</FormLabel>
                 <Input bg='white' {...register('title')} />

--- a/src/interfaces/Corpus.ts
+++ b/src/interfaces/Corpus.ts
@@ -1,0 +1,1 @@
+export type TCorpusType = 'Intl. agreements' | 'Laws and Policies'

--- a/src/interfaces/Family.ts
+++ b/src/interfaces/Family.ts
@@ -1,4 +1,5 @@
 import { TOrganisation } from './Organisation'
+import { TCorpusType } from './Corpus'
 
 interface IFamilyBase {
   import_id: string
@@ -14,6 +15,8 @@ interface IFamilyBase {
   documents: string[]
   collections: string[]
   organisation: TOrganisation
+  corpus_id: string
+  corpus_type: TCorpusType
   created: string
   last_modified: string
 }

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,6 +1,7 @@
 export * from './Auth'
 export * from './Config'
 export * from './Collection'
+export * from './Corpus'
 export * from './Document'
 export * from './Event'
 export * from './Family'


### PR DESCRIPTION
# What's changed

- Show corpus_id and corpus_type as read only

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [x] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
