### PR TITLE
Feature/pdct 1055 frontend create family enable the user to select the corpus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ rebuild: stop build run_ci
 with_local: build_dev
 	docker run --rm -it \
 		-p ${VITE_PORT}:${VITE_PORT} \
-		--network=navigator-backend_default \
+		--network=navigator-admin-backend_default \
 		--env-file "${PWD}/.env" \
 		--mount type=bind,source="${PWD}",target=/app \
 		$(TAG)

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -610,43 +610,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                   )
                 }}
               />
-              <Controller
-                control={control}
-                name='organisation'
-                render={({ field }) => {
-                  return (
-                    <FormControl
-                      isRequired
-                      as='fieldset'
-                      isInvalid={!!errors.organisation}
-                    >
-                      <FormLabel as='legend'>Organisation</FormLabel>
-                      <RadioGroup {...field}>
-                        <HStack gap={4}>
-                          <Radio
-                            bg='white'
-                            value='CCLW'
-                            isDisabled={userAccess && !('CCLW' in userAccess)}
-                          >
-                            CCLW
-                          </Radio>
-                          <Radio
-                            bg='white'
-                            value='UNFCCC'
-                            isDisabled={userAccess && !('UNFCCC' in userAccess)}
-                          >
-                            UNFCCC
-                          </Radio>
-                        </HStack>
-                      </RadioGroup>
-                      <FormErrorMessage>
-                        Please select an organisation
-                      </FormErrorMessage>
-                    </FormControl>
-                  )
-                }}
-              />
-              {!!watchOrganisation && (
+              {!!loadedFamily?.corpus_type && (
                 <Box position='relative' padding='10'>
                   <Divider />
                   <AbsoluteCenter bg='gray.50' px='4'>
@@ -654,7 +618,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                   </AbsoluteCenter>
                 </Box>
               )}
-              {watchOrganisation === 'UNFCCC' && (
+              {loadedFamily?.corpus_type === 'Intl. agreements' && (
                 <>
                   <FormControl isRequired>
                     <FormLabel>Author</FormLabel>
@@ -695,7 +659,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                   />
                 </>
               )}
-              {watchOrganisation === 'CCLW' && (
+              {loadedFamily?.corpus_type === 'Laws and Policies' && (
                 <>
                   <Controller
                     control={control}

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -479,44 +479,41 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
             <VStack gap='4' mb={12} mt={4} align={'stretch'}>
               {formError && <ApiError error={formError} />}
               {loadedFamily && (
-                <FormControl isRequired isReadOnly isDisabled>
-                  <FormLabel>Import ID</FormLabel>
-                  <Input
-                    data-test-id='input-id'
-                    bg='white'
-                    value={loadedFamily?.import_id}
-                  />
-                </FormControl>
-              )}
-              {loadedFamily && (
-                <FormControl isRequired isReadOnly isDisabled>
-                  <FormLabel>Corpus ID</FormLabel>
-                  <Input
-                    data-test-id='corpus-id'
-                    bg='white'
-                    value={loadedFamily?.corpus_id}
-                  />
-                </FormControl>
-              )}
-              {loadedFamily && (
-                <FormControl isRequired isReadOnly isDisabled>
-                  <FormLabel>Corpus Title</FormLabel>
-                  <Input
-                    data-test-id='corpus-type'
-                    bg='white'
-                    value={loadedFamily?.corpus_title}
-                  />
-                </FormControl>
-              )}
-              {loadedFamily && (
-                <FormControl isRequired isReadOnly isDisabled>
-                  <FormLabel>Corpus Type</FormLabel>
-                  <Input
-                    data-test-id='corpus-type'
-                    bg='white'
-                    value={loadedFamily?.corpus_type}
-                  />
-                </FormControl>
+                <>
+                  <FormControl isRequired isReadOnly isDisabled>
+                    <FormLabel>Import ID</FormLabel>
+                    <Input
+                      data-test-id='input-id'
+                      bg='white'
+                      value={loadedFamily?.import_id}
+                    />
+                  </FormControl>
+                  <FormControl isRequired isReadOnly isDisabled>
+                    <FormLabel>Corpus ID</FormLabel>
+                    <Input
+                      data-test-id='corpus-id'
+                      bg='white'
+                      value={loadedFamily?.corpus_id}
+                    />
+                  </FormControl>
+
+                  <FormControl isRequired isReadOnly isDisabled>
+                    <FormLabel>Corpus Title</FormLabel>
+                    <Input
+                      data-test-id='corpus-title'
+                      bg='white'
+                      value={loadedFamily?.corpus_title}
+                    />
+                  </FormControl>
+                  <FormControl isRequired isReadOnly isDisabled>
+                    <FormLabel>Corpus Type</FormLabel>
+                    <Input
+                      data-test-id='corpus-type'
+                      bg='white'
+                      value={loadedFamily?.corpus_type}
+                    />
+                  </FormControl>
+                </>
               )}
               <FormControl isRequired>
                 <FormLabel>Title</FormLabel>

--- a/src/interfaces/Config.ts
+++ b/src/interfaces/Config.ts
@@ -13,6 +13,14 @@ export interface IConfigGeography {
   node: IConfigGeographyNode
   children: IConfigGeography[]
 }
+interface IChakraSelect extends OptionBase {
+  value: string
+  label: string
+}
+
+export interface IConfigLanguageSorted extends IChakraSelect {}
+
+export interface IConfigCorpus extends IChakraSelect {}
 
 export interface IConfigLanguageSorted extends OptionBase {
   value: string
@@ -56,11 +64,11 @@ export interface IConfig {
     [key: string]: string
   }
   languagesSorted: IConfigLanguageSorted[]
-  corpora: IConfigCorpora[]
   taxonomies: {
     CCLW: IConfigTaxonomyCCLW
     UNFCCC: IConfigTaxonomyUNFCCC
   }
+  corpora: IConfigCorpora[]
   document: {
     roles: string[]
     types: string[]

--- a/src/interfaces/Config.ts
+++ b/src/interfaces/Config.ts
@@ -14,15 +14,40 @@ export interface IConfigGeography {
   children: IConfigGeography[]
 }
 
+export interface IConfigLanguageSorted extends OptionBase {
+  value: string
+  label: string
+}
+
 interface IConfigMeta {
   allow_any?: boolean
   allow_blanks: boolean
   allowed_values: string[]
 }
 
-export interface IConfigLanguageSorted extends OptionBase {
-  value: string
-  label: string
+export interface IConfigTaxonomyCCLW {
+  topic: IConfigMeta
+  hazard: IConfigMeta
+  sector: IConfigMeta
+  keyword: IConfigMeta
+  framework: IConfigMeta
+  instrument: IConfigMeta
+  event_type: IConfigMeta
+}
+
+export interface IConfigTaxonomyUNFCCC {
+  author: IConfigMeta
+  author_type: IConfigMeta
+  event_type: IConfigMeta
+}
+
+export interface IConfigCorpora {
+  corpus_import_id: string
+  title: string
+  description: string
+  corpus_type: string
+  corpus_type_description: string
+  taxonomy: IConfigTaxonomyCCLW | IConfigTaxonomyUNFCCC
 }
 
 export interface IConfig {
@@ -31,19 +56,10 @@ export interface IConfig {
     [key: string]: string
   }
   languagesSorted: IConfigLanguageSorted[]
+  corpora: IConfigCorpora[]
   taxonomies: {
-    CCLW: {
-      topic: IConfigMeta
-      hazard: IConfigMeta
-      sector: IConfigMeta
-      keyword: IConfigMeta
-      framework: IConfigMeta
-      instrument: IConfigMeta
-    }
-    UNFCCC: {
-      author: IConfigMeta
-      author_type: IConfigMeta
-    }
+    CCLW: IConfigTaxonomyCCLW
+    UNFCCC: IConfigTaxonomyUNFCCC
   }
   document: {
     roles: string[]

--- a/src/interfaces/Family.ts
+++ b/src/interfaces/Family.ts
@@ -15,7 +15,7 @@ interface IFamilyBase {
   documents: string[]
   collections: string[]
   organisation: TOrganisation
-  corpus_id: string
+  corpus_import_id: string
   corpus_title: string
   corpus_type: TCorpusType
   created: string
@@ -54,6 +54,7 @@ interface IFamilyFormPostBase {
   geography: string
   category: string
   organisation: string
+  corpus_import_id: string
   collections: string[]
 }
 

--- a/src/schemas/familySchema.ts
+++ b/src/schemas/familySchema.ts
@@ -7,6 +7,10 @@ export const familySchema = yup
     geography: yup.string().required(),
     category: yup.string().required(),
     organisation: yup.string().required(),
+    corpus: yup.object({
+      label: yup.string().required(),
+      value: yup.string().required(),
+    }),
     collections: yup.array().optional(),
     author: yup.string().when('organisation', {
       is: 'UNFCCC',

--- a/src/tests/components/forms/FamilyForm.test.tsx
+++ b/src/tests/components/forms/FamilyForm.test.tsx
@@ -79,14 +79,14 @@ jest.mock('@/utils/decodeToken', () => ({
   }),
 }))
 
-const renderComponent = (mockFamily: TFamily) =>
+const renderComponent = (mockFamily: TFamily | undefined) =>
   render(
     <TestWrapper>
       <FamilyForm family={mockFamily} />
     </TestWrapper>,
   )
 
-describe('FamilyList', () => {
+describe('FamilyForm', () => {
   beforeAll(() => configure({ testIdAttribute: 'data-test-id' }))
 
   beforeEach(() => {
@@ -107,14 +107,18 @@ describe('FamilyList', () => {
     ).toBeInTheDocument()
   })
 
-  it('renders family data', async () => {
+  it('renders FamilyReadDTO data on edit', async () => {
     const testFamily = mockFamiliesData[1]
     localStorage.setItem('token', 'token')
     const { getByTestId } = renderComponent(testFamily)
     await flushPromises()
 
-    const input = getByTestId('input-id')
-    expect(input).toHaveValue(testFamily.import_id)
+    expect(getByTestId('input-id')).toHaveValue(testFamily.import_id)
+    expect(getByTestId('corpus-id')).toHaveValue(testFamily.corpus_import_id)
+    expect(getByTestId('corpus-title')).toHaveValue(testFamily.corpus_title)
+    expect(getByTestId('corpus-type')).toHaveValue(testFamily.corpus_type)
+
+    expect(screen.queryByText('corpus')).toBeNull() // it doesn't exist
   })
 })
 

--- a/src/tests/utils/modifyConfig.test.ts
+++ b/src/tests/utils/modifyConfig.test.ts
@@ -27,6 +27,7 @@ describe('modifyConfig', () => {
         },
       ],
       languagesSorted: [],
+      corpora: [], // TODO
       taxonomies: {
         CCLW: {
           topic: { allow_blanks: false, allowed_values: ['topic1', 'topic2'] },
@@ -50,6 +51,10 @@ describe('modifyConfig', () => {
             allow_blanks: false,
             allowed_values: ['instrument1', 'instrument2'],
           },
+          event_type: {
+            allow_blanks: false,
+            allowed_values: ['eventType1', 'eventType2'],
+          }, // TODO
         },
         UNFCCC: {
           author: {
@@ -60,6 +65,10 @@ describe('modifyConfig', () => {
             allow_blanks: false,
             allowed_values: ['authorType1', 'authorType2'],
           },
+          event_type: {
+            allow_blanks: false,
+            allowed_values: ['eventType1', 'eventType2'],
+          }, // TODO
         },
       },
       event: {
@@ -89,6 +98,7 @@ describe('modifyConfig', () => {
       languages: {},
       geographies: [],
       languagesSorted: [],
+      corpora: [],
       taxonomies: {
         CCLW: {
           topic: { allow_blanks: false, allowed_values: [] },
@@ -97,10 +107,12 @@ describe('modifyConfig', () => {
           keyword: { allow_blanks: false, allowed_values: [] },
           framework: { allow_blanks: false, allowed_values: [] },
           instrument: { allow_blanks: false, allowed_values: [] },
+          event_type: { allow_blanks: false, allowed_values: [] },
         },
         UNFCCC: {
           author: { allow_blanks: false, allowed_values: [] },
           author_type: { allow_blanks: false, allowed_values: [] },
+          event_type: { allow_blanks: false, allowed_values: [] },
         },
       },
       event: {

--- a/src/tests/utilsTest/mocks.tsx
+++ b/src/tests/utilsTest/mocks.tsx
@@ -1,3 +1,4 @@
+import { IConfig } from '@/interfaces'
 import { ICCLWFamily, IUNFCCCFamily } from '@/interfaces/Family'
 
 const mockConfig = {
@@ -22,6 +23,7 @@ const mockConfig = {
     { value: 'en', label: 'English' },
     { value: 'es', label: 'Spanish' },
   ],
+  corpora: [],
   taxonomies: {
     CCLW: {
       topic: {
@@ -54,6 +56,11 @@ const mockConfig = {
         allow_blanks: false,
         allowed_values: ['Instrument One', 'Instrument Two'],
       },
+      event_type: {
+        allow_any: false,
+        allow_blanks: false,
+        allowed_values: ['Event One', 'Event Two'],
+      },
     },
     UNFCCC: {
       author: {
@@ -65,6 +72,11 @@ const mockConfig = {
         allow_any: false,
         allow_blanks: false,
         allowed_values: ['Type One', 'Type Two'],
+      },
+      event_type: {
+        allow_any: false,
+        allow_blanks: false,
+        allowed_values: ['Event One', 'Event Two'],
       },
     },
   },
@@ -92,7 +104,7 @@ const mockUNFCCCFamily: IUNFCCCFamily = {
   documents: ['document1', 'document2'],
   collections: ['collection1', 'collection2'],
   organisation: 'UNFCCC',
-  corpus_id: 'UNFCCC.corpus.i00000001.n0000',
+  corpus_import_id: 'UNFCCC.corpus.i00000001.n0000',
   corpus_title: 'UNFCCC Submissions',
   corpus_type: 'Intl. agreements',
   created: '3/1/2021',
@@ -117,7 +129,7 @@ const mockCCLWFamily: ICCLWFamily = {
   documents: ['document3', 'document4'],
   collections: ['collection3', 'collection4'],
   organisation: 'CCLW',
-  corpus_id: 'CCLW.corpus.i00000001.n0000',
+  corpus_import_id: 'CCLW.corpus.i00000001.n0000',
   corpus_title: 'CCLW national policies',
   corpus_type: 'Laws and Policies',
   created: '3/2/2021',
@@ -137,8 +149,8 @@ const mockUNFCCCFamilyNoDocumentsNoEvents: IUNFCCCFamily = {
   import_id: 'UNFCCC.family.3.0',
   title: 'UNFCCC Family Three',
   summary: 'Summary for UNFCCC Family Three with no documents and no events',
-  documents: [], // Sin documentos
-  events: [], // Sin eventos
+  documents: [], // Without documents
+  events: [], // Without events
   created: '5/1/2021',
   last_modified: '6/1/2021',
 }
@@ -148,7 +160,7 @@ const mockCCLWFamilyNoDocuments: ICCLWFamily = {
   import_id: 'CCLW.family.4.0',
   title: 'CCLW Family Four',
   summary: 'Summary for CCLW Family Four with no documents',
-  documents: [], // Sin documentos
+  documents: [], // Without documents
   created: '5/2/2021',
   last_modified: '6/2/2021',
 }
@@ -158,7 +170,7 @@ const mockCCLWFamilyNoEvents: ICCLWFamily = {
   import_id: 'CCLW.family.5.0',
   title: 'CCLW Family Five',
   summary: 'Summary for CCLW Family Five with no events',
-  events: [], // Sin eventos
+  events: [], // Without events
   created: '7/2/2021',
   last_modified: '8/2/2021',
 }
@@ -180,6 +192,86 @@ const mockDocument = {
   user_language_name: 'lang',
 }
 
+const mockCCLWConfig: IConfig = {
+  ...mockConfig,
+  corpora: [
+    {
+      corpus_import_id: 'CCLW.corpus.i00000001.n0000',
+      title: 'CCLW national policies',
+      description: 'UNFCCC Submissions',
+      corpus_type: 'CCLW national policies',
+      corpus_type_description: 'Laws and Policies',
+      taxonomy: {
+        topic: {
+          allow_any: false,
+          allow_blanks: false,
+          allowed_values: ['Topic One', 'Topic Two'],
+        },
+        hazard: {
+          allow_any: false,
+          allow_blanks: false,
+          allowed_values: ['Hazard One', 'Hazard Two'],
+        },
+        sector: {
+          allow_any: false,
+          allow_blanks: false,
+          allowed_values: ['Sector One', 'Sector Two'],
+        },
+        keyword: {
+          allow_any: false,
+          allow_blanks: false,
+          allowed_values: ['Keyword One', 'Keyword Two'],
+        },
+        framework: {
+          allow_any: false,
+          allow_blanks: false,
+          allowed_values: ['Framework One', 'Framework Two'],
+        },
+        instrument: {
+          allow_any: false,
+          allow_blanks: false,
+          allowed_values: ['Instrument One', 'Instrument Two'],
+        },
+        event_type: {
+          allow_any: false,
+          allow_blanks: false,
+          allowed_values: ['Event One', 'Event Two'],
+        },
+      },
+    },
+  ],
+}
+
+const mockUNFCCCConfig: IConfig = {
+  ...mockConfig,
+  corpora: [
+    {
+      corpus_import_id: 'UNFCCC.corpus.i00000001.n0000',
+      title: 'UNFCCC Submissions',
+      description: 'UNFCCC Submissions',
+      corpus_type: 'Intl. agreements',
+      corpus_type_description: 'Intl. agreements',
+      taxonomy: {
+        author: {
+          allow_any: false,
+          allow_blanks: false,
+          allowed_values: ['Author One', 'Author Two'],
+        },
+        author_type: {
+          allow_any: false,
+          allow_blanks: false,
+          allowed_values: ['Type One', 'Type Two'],
+        },
+        event_type: {
+          allow_any: false,
+          allow_blanks: false,
+          allowed_values: ['Event One', 'Event Two'],
+        },
+      },
+    },
+  ],
+}
+
 // Exports
 export const mockFamiliesData = [
   mockUNFCCCFamily,
@@ -189,4 +281,6 @@ export const mockFamiliesData = [
   mockCCLWFamilyNoEvents,
 ]
 export { mockConfig as configMock }
+export { mockCCLWConfig as cclwConfigMock }
+export { mockUNFCCCConfig as unfcccConfigMock }
 export { mockDocument }


### PR DESCRIPTION
# What's changed

- Allow the user to select the desired corpus on family create
- Updated tests

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [x] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
