### PR TITLE
Disable/hide CRUD buttons if org mismatch

### DIFF
--- a/src/components/buttons/Delete.tsx
+++ b/src/components/buttons/Delete.tsx
@@ -17,10 +17,16 @@ import { GoX } from 'react-icons/go'
 interface IProps {
   entityName: string
   entityTitle: string
+  isDisabled?: boolean
   callback?: () => void
 }
 
-export const DeleteButton = ({ entityName, entityTitle, callback }: IProps) => {
+export const DeleteButton = ({
+  entityName,
+  entityTitle,
+  isDisabled,
+  callback,
+}: IProps) => {
   const { isOpen, onOpen, onClose } = useDisclosure()
   const cancelRef = useRef(null)
 
@@ -62,9 +68,28 @@ export const DeleteButton = ({ entityName, entityTitle, callback }: IProps) => {
             <Button ref={cancelRef} onClick={onClose}>
               No
             </Button>
-            <Button colorScheme='red' ml={3} onClick={handleConfirmClick}>
-              Yes
-            </Button>
+            {!isDisabled && (
+              <Button
+                isDisabled={isDisabled}
+                colorScheme='red'
+                ml={3}
+                onClick={handleConfirmClick}
+              >
+                Yes
+              </Button>
+            )}
+            {isDisabled && (
+              <Tooltip label="You don't have the required permissions">
+                <Button
+                  isDisabled={isDisabled}
+                  colorScheme='red'
+                  ml={3}
+                  onClick={handleConfirmClick}
+                >
+                  Yes
+                </Button>
+              </Tooltip>
+            )}
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/src/components/buttons/Delete.tsx
+++ b/src/components/buttons/Delete.tsx
@@ -68,7 +68,10 @@ export const DeleteButton = ({
             <Button ref={cancelRef} onClick={onClose}>
               No
             </Button>
-            {!isDisabled && (
+            <Tooltip
+              label="You don't have the required permissions"
+              isDisabled={!isDisabled}
+            >
               <Button
                 isDisabled={isDisabled}
                 colorScheme='red'
@@ -77,19 +80,7 @@ export const DeleteButton = ({
               >
                 Yes
               </Button>
-            )}
-            {isDisabled && (
-              <Tooltip label="You don't have the required permissions">
-                <Button
-                  isDisabled={isDisabled}
-                  colorScheme='red'
-                  ml={3}
-                  onClick={handleConfirmClick}
-                >
-                  Yes
-                </Button>
-              </Tooltip>
-            )}
+            </Tooltip>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/src/components/family/FamilyDocument.tsx
+++ b/src/components/family/FamilyDocument.tsx
@@ -17,12 +17,14 @@ import { getStatusColour } from '@/utils/getStatusColour'
 
 type TProps = {
   documentId: string
+  canAccess: boolean
   onEditClick?: (document: IDocument) => void
   onDeleteClick?: (documentId: string) => void
 }
 
 export const FamilyDocument = ({
   documentId,
+  canAccess,
   onEditClick,
   onDeleteClick,
 }: TProps) => {
@@ -76,8 +78,9 @@ export const FamilyDocument = ({
                   Edit
                 </Button>
               )}
-              {!!onDeleteClick && (
+              {canAccess && !!onDeleteClick && (
                 <DeleteButton
+                  isDisabled={!canAccess}
                   entityName='document'
                   entityTitle={document?.title || ''}
                   callback={handleDeleteClick}

--- a/src/components/family/FamilyDocument.tsx
+++ b/src/components/family/FamilyDocument.tsx
@@ -17,14 +17,14 @@ import { getStatusColour } from '@/utils/getStatusColour'
 
 type TProps = {
   documentId: string
-  canAccess: boolean
+  canModify: boolean
   onEditClick?: (document: IDocument) => void
   onDeleteClick?: (documentId: string) => void
 }
 
 export const FamilyDocument = ({
   documentId,
-  canAccess,
+  canModify,
   onEditClick,
   onDeleteClick,
 }: TProps) => {
@@ -78,9 +78,9 @@ export const FamilyDocument = ({
                   Edit
                 </Button>
               )}
-              {canAccess && !!onDeleteClick && (
+              {!!onDeleteClick && (
                 <DeleteButton
-                  isDisabled={!canAccess}
+                  isDisabled={!canModify}
                   entityName='document'
                   entityTitle={document?.title || ''}
                   callback={handleDeleteClick}

--- a/src/components/family/FamilyEvent.tsx
+++ b/src/components/family/FamilyEvent.tsx
@@ -16,14 +16,14 @@ import { IEvent } from '@/interfaces'
 
 type TProps = {
   eventId: string
-  canAccess: boolean
+  canModify: boolean
   onEditClick?: (event: IEvent) => void
   onDeleteClick?: (eventId: string) => void
 }
 
 export const FamilyEvent = ({
   eventId,
-  canAccess,
+  canModify,
   onEditClick,
   onDeleteClick,
 }: TProps) => {
@@ -68,9 +68,9 @@ export const FamilyEvent = ({
                 Edit
               </Button>
             )}
-            {canAccess && !!onDeleteClick && (
+            {!!onDeleteClick && (
               <DeleteButton
-                isDisabled={!canAccess}
+                isDisabled={!canModify}
                 entityName='event'
                 entityTitle={event?.event_title || ''}
                 callback={handleDeleteClick}

--- a/src/components/family/FamilyEvent.tsx
+++ b/src/components/family/FamilyEvent.tsx
@@ -16,12 +16,14 @@ import { IEvent } from '@/interfaces'
 
 type TProps = {
   eventId: string
+  canAccess: boolean
   onEditClick?: (event: IEvent) => void
   onDeleteClick?: (eventId: string) => void
 }
 
 export const FamilyEvent = ({
   eventId,
+  canAccess,
   onEditClick,
   onDeleteClick,
 }: TProps) => {
@@ -66,8 +68,9 @@ export const FamilyEvent = ({
                 Edit
               </Button>
             )}
-            {!!onDeleteClick && (
+            {canAccess && !!onDeleteClick && (
               <DeleteButton
+                isDisabled={!canAccess}
                 entityName='event'
                 entityTitle={event?.event_title || ''}
                 callback={handleDeleteClick}

--- a/src/components/forms/DocumentForm.tsx
+++ b/src/components/forms/DocumentForm.tsx
@@ -33,14 +33,14 @@ import { chakraStylesSelect } from '@/styles/chakra'
 type TProps = {
   document?: IDocument
   familyId?: string
-  canAccess?: boolean
+  canModify?: boolean
   onSuccess?: (documentId: string) => void
 }
 
 export const DocumentForm = ({
   document: loadedDocument,
   familyId,
-  canAccess,
+  canModify,
   onSuccess,
 }: TProps) => {
   const { config, loading: configLoading, error: configError } = useConfig()
@@ -267,7 +267,7 @@ export const DocumentForm = ({
               )
             }}
           />
-          <ButtonGroup isDisabled={canAccess}>
+          <ButtonGroup isDisabled={!canModify}>
             <Button
               type='submit'
               colorScheme='blue'

--- a/src/components/forms/DocumentForm.tsx
+++ b/src/components/forms/DocumentForm.tsx
@@ -33,12 +33,14 @@ import { chakraStylesSelect } from '@/styles/chakra'
 type TProps = {
   document?: IDocument
   familyId?: string
+  canAccess?: boolean
   onSuccess?: (documentId: string) => void
 }
 
 export const DocumentForm = ({
   document: loadedDocument,
   familyId,
+  canAccess,
   onSuccess,
 }: TProps) => {
   const { config, loading: configLoading, error: configError } = useConfig()
@@ -265,7 +267,7 @@ export const DocumentForm = ({
               )
             }}
           />
-          <ButtonGroup>
+          <ButtonGroup isDisabled={canAccess}>
             <Button
               type='submit'
               colorScheme='blue'

--- a/src/components/forms/EventForm.tsx
+++ b/src/components/forms/EventForm.tsx
@@ -23,7 +23,7 @@ import { formatDateISO } from '@/utils/formatDate'
 
 type TProps = {
   familyId: string
-  canAccess: boolean
+  canModify: boolean
   event?: IEvent
   onSuccess?: (eventId: string) => void
 }
@@ -36,7 +36,7 @@ type TEventForm = {
 
 export const EventForm = ({
   familyId,
-  canAccess,
+  canModify,
   event: loadedEvent,
   onSuccess,
 }: TProps) => {
@@ -170,7 +170,7 @@ export const EventForm = ({
               )
             }}
           />
-          <ButtonGroup isDisabled={canAccess}>
+          <ButtonGroup isDisabled={!canModify}>
             <Button
               type='submit'
               colorScheme='blue'

--- a/src/components/forms/EventForm.tsx
+++ b/src/components/forms/EventForm.tsx
@@ -23,6 +23,7 @@ import { formatDateISO } from '@/utils/formatDate'
 
 type TProps = {
   familyId: string
+  canAccess: boolean
   event?: IEvent
   onSuccess?: (eventId: string) => void
 }
@@ -35,6 +36,7 @@ type TEventForm = {
 
 export const EventForm = ({
   familyId,
+  canAccess,
   event: loadedEvent,
   onSuccess,
 }: TProps) => {
@@ -168,7 +170,7 @@ export const EventForm = ({
               )
             }}
           />
-          <ButtonGroup>
+          <ButtonGroup isDisabled={canAccess}>
             <Button
               type='submit'
               colorScheme='blue'

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -881,6 +881,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                 <Flex direction='column' gap={4}>
                   {familyDocuments.map((familyDoc) => (
                     <FamilyDocument
+                      canAccess={canAccess(watchOrganisation)}
                       documentId={familyDoc}
                       key={familyDoc}
                       onEditClick={(id) => onEditEntityClick('document', id)}
@@ -892,6 +893,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
               {loadedFamily && (
                 <Box>
                   <Button
+                    isDisabled={!canAccess(watchOrganisation)}
                     onClick={() => onAddNewEntityClick('document')}
                     rightIcon={
                       familyDocuments.length === 0 ? (
@@ -921,6 +923,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                 <Flex direction='column' gap={4}>
                   {familyEvents.map((familyEvent) => (
                     <FamilyEvent
+                      canAccess={canAccess(watchOrganisation)}
                       eventId={familyEvent}
                       key={familyEvent}
                       onEditClick={(event) => onEditEntityClick('event', event)}
@@ -932,6 +935,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
               {loadedFamily && (
                 <Box>
                   <Button
+                    isDisabled={!canAccess(watchOrganisation)}
                     onClick={() => onAddNewEntityClick('event')}
                     rightIcon={
                       familyEvents.length === 0 ? (
@@ -971,6 +975,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                 <DrawerBody>
                   <DocumentForm
                     familyId={loadedFamily.import_id}
+                    canAccess={!canAccess(watchOrganisation)}
                     onSuccess={onDocumentFormSuccess}
                     document={editingDocument}
                   />
@@ -987,6 +992,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                 <DrawerBody>
                   <EventForm
                     familyId={loadedFamily.import_id}
+                    canAccess={!canAccess(watchOrganisation)}
                     onSuccess={onEventFormSuccess}
                     event={editingEvent}
                   />

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -19,6 +19,7 @@ import {
 import { createFamily, updateFamily } from '@/api/Families'
 import { deleteDocument } from '@/api/Documents'
 import useConfig from '@/hooks/useConfig'
+import { canModify } from '@/utils/canModify'
 
 import {
   Box,
@@ -330,12 +331,6 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
   const canLoadForm =
     !configLoading && !collectionsLoading && !configError && !collectionsError
 
-  const canAccess = (organisation: string) => {
-    if (!organisation) return true
-    if (!userAccess) return false
-    return organisation in userAccess
-  }
-
   useEffect(() => {
     if (loadedFamily) {
       setFamilyDocuments(loadedFamily.documents)
@@ -437,7 +432,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
           <SkeletonText mt='4' noOfLines={12} spacing='4' skeletonHeight='2' />
         </Box>
       )}
-      {!canAccess(watchOrganisation) && (
+      {!canModify(watchOrganisation, userAccess) && (
         <ApiError
           message={`You do not have permission to edit ${watchOrganisation} document families`}
           detail='Please go back to the "Families" page, if you think there has been a mistake please contact the administrator.'
@@ -881,7 +876,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                 <Flex direction='column' gap={4}>
                   {familyDocuments.map((familyDoc) => (
                     <FamilyDocument
-                      canAccess={canAccess(watchOrganisation)}
+                      canModify={canModify(watchOrganisation, userAccess)}
                       documentId={familyDoc}
                       key={familyDoc}
                       onEditClick={(id) => onEditEntityClick('document', id)}
@@ -893,7 +888,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
               {loadedFamily && (
                 <Box>
                   <Button
-                    isDisabled={!canAccess(watchOrganisation)}
+                    isDisabled={canModify(watchOrganisation, userAccess)}
                     onClick={() => onAddNewEntityClick('document')}
                     rightIcon={
                       familyDocuments.length === 0 ? (
@@ -923,7 +918,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                 <Flex direction='column' gap={4}>
                   {familyEvents.map((familyEvent) => (
                     <FamilyEvent
-                      canAccess={canAccess(watchOrganisation)}
+                      canModify={canModify(watchOrganisation, userAccess)}
                       eventId={familyEvent}
                       key={familyEvent}
                       onEditClick={(event) => onEditEntityClick('event', event)}
@@ -935,7 +930,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
               {loadedFamily && (
                 <Box>
                   <Button
-                    isDisabled={!canAccess(watchOrganisation)}
+                    isDisabled={canModify(watchOrganisation, userAccess)}
                     onClick={() => onAddNewEntityClick('event')}
                     rightIcon={
                       familyEvents.length === 0 ? (
@@ -952,7 +947,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
               )}
             </VStack>
 
-            <ButtonGroup isDisabled={!canAccess(watchOrganisation)}>
+            <ButtonGroup isDisabled={!canModify(watchOrganisation, userAccess)}>
               <Button
                 type='submit'
                 colorScheme='blue'
@@ -975,7 +970,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                 <DrawerBody>
                   <DocumentForm
                     familyId={loadedFamily.import_id}
-                    canAccess={!canAccess(watchOrganisation)}
+                    canModify={canModify(watchOrganisation, userAccess)}
                     onSuccess={onDocumentFormSuccess}
                     document={editingDocument}
                   />
@@ -992,7 +987,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                 <DrawerBody>
                   <EventForm
                     familyId={loadedFamily.import_id}
-                    canAccess={!canAccess(watchOrganisation)}
+                    canModify={canModify(watchOrganisation, userAccess)}
                     onSuccess={onEventFormSuccess}
                     event={editingEvent}
                   />

--- a/src/components/lists/FamilyList.tsx
+++ b/src/components/lists/FamilyList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import { Link, useLoaderData } from 'react-router-dom'
 import { deleteFamily, getFamilies, TFamilySearchQuery } from '@/api/Families'
 import { IError, TFamily } from '@/interfaces'
@@ -32,6 +32,8 @@ import {
 import { getStatusColour } from '@/utils/getStatusColour'
 import { getStatusAlias } from '@/utils/getStatusAlias'
 import { ApiError } from '../feedback/ApiError'
+import { canModify } from '@/utils/canModify'
+import { decodeToken } from '@/utils/decodeToken'
 
 interface ILoaderProps {
   request: {
@@ -70,6 +72,13 @@ export default function FamilyList() {
   const toast = useToast()
   const [familyError, setFamilyError] = useState<string | null | undefined>()
   const [formError, setFormError] = useState<IError | null | undefined>()
+
+  const userAccess = useMemo(() => {
+    const token = localStorage.getItem('token')
+    if (!token) return []
+    const decodedToken = decodeToken(token)
+    return decodedToken?.authorisation
+  }, [])
 
   const renderSortIcon = (key: keyof TFamily) => {
     if (sortControls.key !== key) {
@@ -257,6 +266,7 @@ export default function FamilyList() {
                       </Link>
                     </Tooltip>
                     <DeleteButton
+                      isDisabled={!canModify(family.organisation, userAccess)}
                       entityName='family'
                       entityTitle={family.title}
                       callback={() => handleDeleteClick(family.import_id)}

--- a/src/tests/components/lists/FamilyList.test.tsx
+++ b/src/tests/components/lists/FamilyList.test.tsx
@@ -4,6 +4,7 @@ import '@testing-library/jest-dom'
 
 import FamilyList from '@/components/lists/FamilyList'
 import { mockFamiliesData } from '@/tests/utilsTest/mocks'
+import { formatDate } from '@/utils/formatDate'
 
 jest.mock('@/api/Families', () => ({
   getFamilies: jest.fn(),
@@ -29,20 +30,25 @@ describe('FamilyList', () => {
   })
 
   it('renders without crashing', () => {
-    // Verify mock family properties are rendered there
+    // Verify expected family properties are rendered there
     expect(screen.queryAllByText(UNFCCCFamily.title)).not.toHaveLength(0)
     expect(screen.queryAllByText(UNFCCCFamily.category)).not.toHaveLength(0)
     expect(screen.queryAllByText(UNFCCCFamily.geography)).not.toHaveLength(0)
-    expect(screen.queryAllByText(UNFCCCFamily.published_date)).not.toHaveLength(
-      0,
-    )
+
+    // We put the formatDate here so that the formatting runs in the same locale
+    // as the component when it runs formatDate.
     expect(
-      screen.queryAllByText(UNFCCCFamily.last_updated_date),
+      screen.queryAllByText(formatDate(UNFCCCFamily.published_date)),
     ).not.toHaveLength(0)
-    expect(screen.queryAllByText(UNFCCCFamily.created)).not.toHaveLength(0)
-    expect(screen.queryAllByText(UNFCCCFamily.last_modified)).not.toHaveLength(
-      0,
-    )
+    expect(
+      screen.queryAllByText(formatDate(UNFCCCFamily.last_updated_date)),
+    ).not.toHaveLength(0)
+    expect(
+      screen.queryAllByText(formatDate(UNFCCCFamily.created)),
+    ).not.toHaveLength(0)
+    expect(
+      screen.queryAllByText(formatDate(UNFCCCFamily.last_modified)),
+    ).not.toHaveLength(0)
   })
 
   it('sorts families by title when title header is clicked', async () => {

--- a/src/tests/utilsTest/mocks.tsx
+++ b/src/tests/utilsTest/mocks.tsx
@@ -99,7 +99,7 @@ const mockUNFCCCFamily: IUNFCCCFamily = {
   status: 'active',
   slug: 'unfccc-family-one',
   events: ['event1', 'event2'],
-  published_date: '1/1/2021',
+  published_date: '1/4/2021',
   last_updated_date: '2/1/2021',
   documents: ['document1', 'document2'],
   collections: ['collection1', 'collection2'],

--- a/src/utils/canModify.ts
+++ b/src/utils/canModify.ts
@@ -1,0 +1,14 @@
+export const canModify = (
+  organisation: string,
+  userAccess?:
+    | never[]
+    | {
+        [key: string]: {
+          is_admin: boolean
+        }
+      },
+) => {
+  if (!organisation) return true
+  if (!userAccess) return false
+  return organisation in userAccess
+}


### PR DESCRIPTION
# What's changed

[PDCT-1104](https://linear.app/climate-policy-radar/issue/PDCT-1104/block-frontend-crud-if-org-mismatch) 

Block CRUD when org mismatch.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
