### PR TITLE
Feature/pdct 1054 frontend addedit family remove the selector for metadata

### DIFF
--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -166,8 +166,6 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
     else return corpus?.taxonomy
   }, [corpus])
 
-  console.log(corpus)
-
   const userAccess = useMemo(() => {
     const token = localStorage.getItem('token')
     if (!token) return []


### PR DESCRIPTION
# What's changed

Remove the organisation selector
Make metadata programmatic based on selected corpus
No longer show metadata on "foreign families"

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
