### PR TITLE
Inverse canModify to enable button when correct permissions

### DIFF
--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -886,7 +886,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
               {loadedFamily && (
                 <Box>
                   <Button
-                    isDisabled={canModify(watchOrganisation, userAccess)}
+                    isDisabled={!canModify(watchOrganisation, userAccess)}
                     onClick={() => onAddNewEntityClick('document')}
                     rightIcon={
                       familyDocuments.length === 0 ? (
@@ -928,7 +928,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
               {loadedFamily && (
                 <Box>
                   <Button
-                    isDisabled={canModify(watchOrganisation, userAccess)}
+                    isDisabled={!canModify(watchOrganisation, userAccess)}
                     onClick={() => onAddNewEntityClick('event')}
                     rightIcon={
                       familyEvents.length === 0 ? (


### PR DESCRIPTION
# What's changed

Inverse canModify to enable button when correct permissions

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
