### PR TITLE
Bug/pdct 1168 unable to create new family on admin service

### DIFF
--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -974,13 +974,11 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
 
             <ButtonGroup
               isDisabled={
-                loadedFamily
-                  ? !canModify(
-                      loadedFamily?.organisation,
-                      isSuperUser,
-                      userAccess,
-                    )
-                  : !canModify(orgName, isSuperUser, userAccess)
+                !canModify(
+                  loadedFamily?.organisation || orgName,
+                  isSuperUser,
+                  userAccess,
+                )
               }
             >
               <Button

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -1,12 +1,17 @@
 import { useEffect, useState, useMemo, useCallback } from 'react'
-import { useForm, SubmitHandler, Controller } from 'react-hook-form'
+import {
+  useForm,
+  SubmitHandler,
+  Controller,
+  SubmitErrorHandler,
+  FieldErrors,
+} from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import { useBlocker, useNavigate } from 'react-router-dom'
 
 import {
   IError,
   TFamilyFormPost,
-  TOrganisation,
   TFamilyFormPostMetadata,
   IUNFCCCMetadata,
   ICCLWMetadata,
@@ -17,6 +22,7 @@ import {
   IConfigCorpus,
   IConfigTaxonomyUNFCCC,
   IConfigTaxonomyCCLW,
+  IDecodedToken,
 } from '@/interfaces'
 import { createFamily, updateFamily } from '@/api/Families'
 import { deleteDocument } from '@/api/Documents'
@@ -85,7 +91,6 @@ interface IFamilyForm {
   summary: string
   geography: string
   category: string
-  organisation: string
   corpus: IConfigCorpus
   collections?: TMultiSelect[]
   author?: string
@@ -140,10 +145,9 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
   >()
   const [familyDocuments, setFamilyDocuments] = useState<string[]>([])
   const [familyEvents, setFamilyEvents] = useState<string[]>([])
-  const watchOrganisation = watch('organisation')
-  const watchCorpus = watch('corpus')
 
-  const corpus = useMemo(() => {
+  const watchCorpus = watch('corpus')
+  const corpusInfo = useMemo(() => {
     const getCorpusFromId = (corpusId: string) => {
       const corp = config?.corpora.find(
         (corpus) => corpus.corpus_import_id === corpusId,
@@ -151,27 +155,38 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
       return corp ? corp : null
     }
 
-    if (loadedFamily) return getCorpusFromId(loadedFamily?.corpus_import_id)
-    else if (watchCorpus) {
+    if (loadedFamily) {
+      return getCorpusFromId(loadedFamily?.corpus_import_id)
+    } else if (watchCorpus) {
       return getCorpusFromId(watchCorpus?.value)
     }
     return null
   }, [config?.corpora, loadedFamily, watchCorpus])
 
-  const taxonomy = useMemo(() => {
-    if (corpus?.corpus_type === 'Law and Policies')
-      return corpus?.taxonomy as IConfigTaxonomyCCLW
-    else if (corpus?.corpus_type === 'Intl. Agreements')
-      return corpus?.taxonomy as IConfigTaxonomyUNFCCC
-    else return corpus?.taxonomy
-  }, [corpus])
+  const corpusTitle = loadedFamily
+    ? loadedFamily?.corpus_title
+    : corpusInfo?.title
 
-  const userAccess = useMemo(() => {
+  const taxonomy = useMemo(() => {
+    if (corpusInfo?.corpus_type === 'Law and Policies')
+      return corpusInfo?.taxonomy as IConfigTaxonomyCCLW
+    else if (corpusInfo?.corpus_type === 'Intl. Agreements')
+      return corpusInfo?.taxonomy as IConfigTaxonomyUNFCCC
+    else return corpusInfo?.taxonomy
+  }, [corpusInfo])
+
+  const userToken = useMemo(() => {
     const token = localStorage.getItem('token')
-    if (!token) return []
-    const decodedToken = decodeToken(token)
-    return decodedToken?.authorisation
+    if (!token) return null
+    const decodedToken: IDecodedToken | null = decodeToken(token)
+    return decodedToken
   }, [])
+
+  const userAccess = !userToken ? null : userToken.authorisation
+  const isSuperuser = !userToken ? null : userToken.is_superuser
+
+  // TODO: Get org_id from corpus PDCT-1171.
+  const orgName = loadedFamily ? String(loadedFamily?.organisation) : null
 
   // Family handlers
   const handleFormSubmission = async (family: IFamilyForm) => {
@@ -179,21 +194,21 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
     setFormError(null)
 
     let familyMetadata = {} as TFamilyFormPostMetadata
-    if (family.organisation === 'UNFCCC') {
+    if (corpusInfo?.corpus_type == 'Intl. Agreements') {
       const metadata = familyMetadata as IUNFCCCMetadata
       if (family.author) metadata.author = [family.author]
       if (family.author_type) metadata.author_type = [family.author_type]
       familyMetadata = metadata
-    } else if (family.organisation === 'CCLW') {
-      const metadata = familyMetadata as ICCLWMetadata
-      metadata.topic = family.topic?.map((topic) => topic.value) || []
-      metadata.hazard = family.hazard?.map((hazard) => hazard.value) || []
-      metadata.sector = family.sector?.map((sector) => sector.value) || []
-      metadata.keyword = family.keyword?.map((keyword) => keyword.value) || []
-      metadata.framework =
-        family.framework?.map((framework) => framework.value) || []
-      metadata.instrument =
-        family.instrument?.map((instrument) => instrument.value) || []
+    } else if (corpusInfo?.corpus_type == 'Laws and Policies') {
+      const metadata: ICCLWMetadata = {
+        topic: family.topic?.map((topic) => topic.value) || [],
+        hazard: family.hazard?.map((hazard) => hazard.value) || [],
+        sector: family.sector?.map((sector) => sector.value) || [],
+        keyword: family.keyword?.map((keyword) => keyword.value) || [],
+        framework: family.framework?.map((framework) => framework.value) || [],
+        instrument:
+          family.instrument?.map((instrument) => instrument.value) || [],
+      }
       familyMetadata = metadata
     }
 
@@ -203,7 +218,6 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
       summary: family.summary,
       geography: family.geography,
       category: family.category,
-      organisation: family.organisation as TOrganisation,
       corpus_import_id: family.corpus?.value || '',
       collections:
         family.collections?.map((collection) => collection.value) || [],
@@ -255,8 +269,16 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
       })
   } // end handleFormSubmission
 
-  const onSubmit: SubmitHandler<IFamilyForm> = (data) =>
-    handleFormSubmission(data)
+  const onSubmit: SubmitHandler<IFamilyForm> = (data) => {
+    handleFormSubmission(data).catch((error: IError) => {
+      console.error(error)
+    })
+  }
+
+  //  SubmitErrorHandler<FieldErrors<IFamilyForm>>
+  const onSubmitErrorHandler: SubmitErrorHandler<FieldErrors> = (error) => {
+    console.log('onSubmitErrorHandler', error)
+  }
 
   // Child entity handlers
   const onAddNewEntityClick = (entityType: TChildEntity) => {
@@ -376,7 +398,6 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
         }),
         geography: loadedFamily.geography,
         category: loadedFamily.category,
-        organisation: loadedFamily.organisation,
         corpus: loadedFamily.corpus_import_id
           ? {
               label: loadedFamily.corpus_import_id,
@@ -459,9 +480,9 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
           <SkeletonText mt='4' noOfLines={12} spacing='4' skeletonHeight='2' />
         </Box>
       )}
-      {!canModify(watchOrganisation, userAccess) && (
+      {!canModify(orgName, isSuperuser, userAccess) && (
         <ApiError
-          message={`You do not have permission to edit ${watchOrganisation} document families`}
+          message={`You do not have permission to edit document families in ${corpusTitle} `}
           detail='Please go back to the "Families" page, if you think there has been a mistake please contact the administrator.'
         />
       )}
@@ -475,7 +496,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
       )}
       {canLoadForm && (
         <>
-          <form onSubmit={handleSubmit(onSubmit)}>
+          <form onSubmit={handleSubmit(onSubmit, onSubmitErrorHandler)}>
             {isLeavingModalOpen && (
               <Modal
                 isOpen={isLeavingModalOpen}
@@ -665,7 +686,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                   )
                 }}
               />
-              {corpus !== null && (
+              {corpusInfo !== null && (
                 <Box position='relative' padding='10'>
                   <Divider />
                   <AbsoluteCenter bg='gray.50' px='4'>
@@ -673,8 +694,8 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                   </AbsoluteCenter>
                 </Box>
               )}
-              {corpus !== null &&
-                corpus?.corpus_type === 'Intl. agreements' && (
+              {corpusInfo !== null &&
+                corpusInfo?.corpus_type === 'Intl. agreements' && (
                   <>
                     <FormControl isRequired>
                       <FormLabel>Author</FormLabel>
@@ -716,8 +737,8 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                     />
                   </>
                 )}
-              {corpus !== null &&
-                corpus?.corpus_type === 'Laws and Policies' && (
+              {corpusInfo !== null &&
+                corpusInfo?.corpus_type === 'Laws and Policies' && (
                   <>
                     <Controller
                       control={control}
@@ -874,7 +895,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                 <Flex direction='column' gap={4}>
                   {familyDocuments.map((familyDoc) => (
                     <FamilyDocument
-                      canModify={canModify(watchOrganisation, userAccess)}
+                      canModify={canModify(orgName, isSuperuser, userAccess)}
                       documentId={familyDoc}
                       key={familyDoc}
                       onEditClick={(id) => onEditEntityClick('document', id)}
@@ -886,7 +907,13 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
               {loadedFamily && (
                 <Box>
                   <Button
-                    isDisabled={!canModify(watchOrganisation, userAccess)}
+                    isDisabled={
+                      !canModify(
+                        loadedFamily?.organisation,
+                        isSuperuser,
+                        userAccess,
+                      )
+                    }
                     onClick={() => onAddNewEntityClick('document')}
                     rightIcon={
                       familyDocuments.length === 0 ? (
@@ -916,7 +943,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                 <Flex direction='column' gap={4}>
                   {familyEvents.map((familyEvent) => (
                     <FamilyEvent
-                      canModify={canModify(watchOrganisation, userAccess)}
+                      canModify={canModify(orgName, isSuperuser, userAccess)}
                       eventId={familyEvent}
                       key={familyEvent}
                       onEditClick={(event) => onEditEntityClick('event', event)}
@@ -928,7 +955,13 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
               {loadedFamily && (
                 <Box>
                   <Button
-                    isDisabled={!canModify(watchOrganisation, userAccess)}
+                    isDisabled={
+                      !canModify(
+                        loadedFamily?.organisation,
+                        isSuperuser,
+                        userAccess,
+                      )
+                    }
                     onClick={() => onAddNewEntityClick('event')}
                     rightIcon={
                       familyEvents.length === 0 ? (
@@ -945,11 +978,21 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
               )}
             </VStack>
 
-            <ButtonGroup isDisabled={!canModify(watchOrganisation, userAccess)}>
+            <ButtonGroup
+              isDisabled={
+                loadedFamily
+                  ? !canModify(
+                      loadedFamily?.organisation,
+                      isSuperuser,
+                      userAccess,
+                    )
+                  : !canModify(orgName, isSuperuser, userAccess)
+              }
+            >
               <Button
                 type='submit'
                 colorScheme='blue'
-                onSubmit={handleSubmit(onSubmit)}
+                onSubmit={handleSubmit(onSubmit, onSubmitErrorHandler)}
                 disabled={isSubmitting}
               >
                 {(loadedFamily ? 'Update ' : 'Create new ') + ' Family'}
@@ -968,7 +1011,11 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                 <DrawerBody>
                   <DocumentForm
                     familyId={loadedFamily.import_id}
-                    canModify={canModify(watchOrganisation, userAccess)}
+                    canModify={canModify(
+                      loadedFamily?.organisation,
+                      isSuperuser,
+                      userAccess,
+                    )}
                     onSuccess={onDocumentFormSuccess}
                     document={editingDocument}
                   />
@@ -985,7 +1032,11 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                 <DrawerBody>
                   <EventForm
                     familyId={loadedFamily.import_id}
-                    canModify={canModify(watchOrganisation, userAccess)}
+                    canModify={canModify(
+                      loadedFamily?.organisation,
+                      isSuperuser,
+                      userAccess,
+                    )}
                     onSuccess={onEventFormSuccess}
                     event={editingEvent}
                   />

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -1,11 +1,5 @@
 import { useEffect, useState, useMemo, useCallback } from 'react'
-import {
-  useForm,
-  SubmitHandler,
-  Controller,
-  SubmitErrorHandler,
-  FieldErrors,
-} from 'react-hook-form'
+import { useForm, SubmitHandler, Controller } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import { useBlocker, useNavigate } from 'react-router-dom'
 
@@ -170,7 +164,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
   const taxonomy = useMemo(() => {
     if (corpusInfo?.corpus_type === 'Law and Policies')
       return corpusInfo?.taxonomy as IConfigTaxonomyCCLW
-    else if (corpusInfo?.corpus_type === 'Intl. Agreements')
+    else if (corpusInfo?.corpus_type === 'Intl. agreements')
       return corpusInfo?.taxonomy as IConfigTaxonomyUNFCCC
     else return corpusInfo?.taxonomy
   }, [corpusInfo])
@@ -183,7 +177,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
   }, [])
 
   const userAccess = !userToken ? null : userToken.authorisation
-  const isSuperuser = !userToken ? null : userToken.is_superuser
+  const isSuperuser = !userToken ? false : userToken.is_superuser
 
   // TODO: Get org_id from corpus PDCT-1171.
   const orgName = loadedFamily ? String(loadedFamily?.organisation) : null
@@ -194,7 +188,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
     setFormError(null)
 
     let familyMetadata = {} as TFamilyFormPostMetadata
-    if (corpusInfo?.corpus_type == 'Intl. Agreements') {
+    if (corpusInfo?.corpus_type == 'Intl. agreements') {
       const metadata = familyMetadata as IUNFCCCMetadata
       if (family.author) metadata.author = [family.author]
       if (family.author_type) metadata.author_type = [family.author_type]
@@ -275,8 +269,8 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
     })
   }
 
-  //  SubmitErrorHandler<FieldErrors<IFamilyForm>>
-  const onSubmitErrorHandler: SubmitErrorHandler<FieldErrors> = (error) => {
+  // object type is workaround for SubmitErrorHandler<FieldErrors> throwing a tsc error.
+  const onSubmitErrorHandler = (error: object) => {
     console.log('onSubmitErrorHandler', error)
   }
 

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -177,7 +177,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
   }, [])
 
   const userAccess = !userToken ? null : userToken.authorisation
-  const isSuperuser = !userToken ? false : userToken.is_superuser
+  const isSuperUser = !userToken ? false : userToken.is_superuser
 
   // TODO: Get org_id from corpus PDCT-1171.
   const orgName = loadedFamily ? String(loadedFamily?.organisation) : null
@@ -474,7 +474,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
           <SkeletonText mt='4' noOfLines={12} spacing='4' skeletonHeight='2' />
         </Box>
       )}
-      {!canModify(orgName, isSuperuser, userAccess) && (
+      {!canModify(orgName, isSuperUser, userAccess) && (
         <ApiError
           message={`You do not have permission to edit document families in ${corpusTitle} `}
           detail='Please go back to the "Families" page, if you think there has been a mistake please contact the administrator.'
@@ -889,7 +889,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                 <Flex direction='column' gap={4}>
                   {familyDocuments.map((familyDoc) => (
                     <FamilyDocument
-                      canModify={canModify(orgName, isSuperuser, userAccess)}
+                      canModify={canModify(orgName, isSuperUser, userAccess)}
                       documentId={familyDoc}
                       key={familyDoc}
                       onEditClick={(id) => onEditEntityClick('document', id)}
@@ -904,7 +904,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                     isDisabled={
                       !canModify(
                         loadedFamily?.organisation,
-                        isSuperuser,
+                        isSuperUser,
                         userAccess,
                       )
                     }
@@ -937,7 +937,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                 <Flex direction='column' gap={4}>
                   {familyEvents.map((familyEvent) => (
                     <FamilyEvent
-                      canModify={canModify(orgName, isSuperuser, userAccess)}
+                      canModify={canModify(orgName, isSuperUser, userAccess)}
                       eventId={familyEvent}
                       key={familyEvent}
                       onEditClick={(event) => onEditEntityClick('event', event)}
@@ -952,7 +952,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                     isDisabled={
                       !canModify(
                         loadedFamily?.organisation,
-                        isSuperuser,
+                        isSuperUser,
                         userAccess,
                       )
                     }
@@ -977,10 +977,10 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                 loadedFamily
                   ? !canModify(
                       loadedFamily?.organisation,
-                      isSuperuser,
+                      isSuperUser,
                       userAccess,
                     )
-                  : !canModify(orgName, isSuperuser, userAccess)
+                  : !canModify(orgName, isSuperUser, userAccess)
               }
             >
               <Button
@@ -1007,7 +1007,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                     familyId={loadedFamily.import_id}
                     canModify={canModify(
                       loadedFamily?.organisation,
-                      isSuperuser,
+                      isSuperUser,
                       userAccess,
                     )}
                     onSuccess={onDocumentFormSuccess}
@@ -1028,7 +1028,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                     familyId={loadedFamily.import_id}
                     canModify={canModify(
                       loadedFamily?.organisation,
-                      isSuperuser,
+                      isSuperUser,
                       userAccess,
                     )}
                     onSuccess={onEventFormSuccess}

--- a/src/components/lists/FamilyList.tsx
+++ b/src/components/lists/FamilyList.tsx
@@ -73,12 +73,15 @@ export default function FamilyList() {
   const [familyError, setFamilyError] = useState<string | null | undefined>()
   const [formError, setFormError] = useState<IError | null | undefined>()
 
-  const userAccess = useMemo(() => {
+  const userToken = useMemo(() => {
     const token = localStorage.getItem('token')
-    if (!token) return []
+    if (!token) return null
     const decodedToken = decodeToken(token)
-    return decodedToken?.authorisation
+    return decodedToken
   }, [])
+
+  const userAccess = !userToken ? null : userToken.authorisation
+  const isSuperuser = !userToken ? false : userToken.is_superuser
 
   const renderSortIcon = (key: keyof TFamily) => {
     if (sortControls.key !== key) {
@@ -266,7 +269,9 @@ export default function FamilyList() {
                       </Link>
                     </Tooltip>
                     <DeleteButton
-                      isDisabled={!canModify(family.organisation, userAccess)}
+                      isDisabled={
+                        !canModify(family.organisation, isSuperuser, userAccess)
+                      }
                       entityName='family'
                       entityTitle={family.title}
                       callback={() => handleDeleteClick(family.import_id)}

--- a/src/interfaces/Auth.ts
+++ b/src/interfaces/Auth.ts
@@ -15,6 +15,7 @@ export interface IError {
 export interface IDecodedToken {
   sub: string
   email: string
+  org_id: number
   is_superuser: boolean
   authorisation: {
     [key: string]: {

--- a/src/schemas/familySchema.ts
+++ b/src/schemas/familySchema.ts
@@ -1,3 +1,4 @@
+import { IConfigCorpus } from '@/interfaces'
 import * as yup from 'yup'
 
 export const familySchema = yup
@@ -11,12 +12,12 @@ export const familySchema = yup
       value: yup.string().required(),
     }),
     collections: yup.array().optional(),
-    author: yup.string().when('organisation', {
-      is: 'UNFCCC',
+    author: yup.string().when('corpus', {
+      is: (val: IConfigCorpus) => val.label == 'UNFCCC Submissions',
       then: (schema) => schema.required(),
     }),
-    author_type: yup.string().when('organisation', {
-      is: 'UNFCCC',
+    author_type: yup.string().when('corpus', {
+      is: (val: IConfigCorpus) => val.label == 'UNFCCC Submissions',
       then: (schema) => schema.required(),
     }),
     topic: yup.array().optional(),

--- a/src/schemas/familySchema.ts
+++ b/src/schemas/familySchema.ts
@@ -6,7 +6,6 @@ export const familySchema = yup
     summary: yup.string().required(),
     geography: yup.string().required(),
     category: yup.string().required(),
-    organisation: yup.string().required(),
     corpus: yup.object({
       label: yup.string().required(),
       value: yup.string().required(),

--- a/src/tests/components/forms/FamilyForm.test.tsx
+++ b/src/tests/components/forms/FamilyForm.test.tsx
@@ -102,7 +102,7 @@ describe('FamilyForm', () => {
 
     expect(
       screen.getByText(
-        'You do not have permission to edit CCLW document families',
+        'You do not have permission to edit document families in CCLW national policies',
       ),
     ).toBeInTheDocument()
   })

--- a/src/utils/canModify.ts
+++ b/src/utils/canModify.ts
@@ -1,6 +1,6 @@
 export const canModify = (
   organisation: string | null,
-  isSuperuser: boolean,
+  isSuperUser: boolean,
   userAccess?:
     | never[]
     | null
@@ -10,7 +10,7 @@ export const canModify = (
         }
       },
 ) => {
-  if (isSuperuser === true) return true
+  if (isSuperUser === true) return true
   if (organisation === null) return true
   if (!userAccess || userAccess === null) return false
   return organisation in userAccess

--- a/src/utils/canModify.ts
+++ b/src/utils/canModify.ts
@@ -1,14 +1,17 @@
 export const canModify = (
-  organisation: string,
+  organisation: string | null,
+  isSuperuser: boolean,
   userAccess?:
     | never[]
+    | null
     | {
         [key: string]: {
           is_admin: boolean
         }
       },
 ) => {
-  if (!organisation) return true
-  if (!userAccess) return false
+  if (isSuperuser === true) return true
+  if (organisation === null) return true
+  if (!userAccess || userAccess === null) return false
   return organisation in userAccess
 }


### PR DESCRIPTION
# What's changed

- Removed organisation validation on family form (cause of bug)
- Corrected UNFCCC validation on family form
- Removed all references to watchOrganisation in family form
- Modify canModify function to enable if superuser and work for creating new families (cause of bug)

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
