### PR TITLE
Pdct 968/bug create family trigger modal always

### DIFF
--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -331,7 +331,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
   }
 
   const summaryOnChange = (html: string) => {
-    setValue('summary', html)
+    setValue('summary', html, { shouldDirty: true })
   }
 
   // Event handlers

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -490,38 +490,38 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
       )}
       {canLoadForm && (
         <>
+          {isLeavingModalOpen && (
+            <Modal
+              isOpen={isLeavingModalOpen}
+              onClose={() => setIsLeavingModalOpen(false)}
+            >
+              <ModalOverlay />
+              <ModalContent>
+                <ModalHeader>Are you sure you want to leave?</ModalHeader>
+                <ModalCloseButton />
+                <ModalBody>Changes that you made may not be saved.</ModalBody>
+                <ModalFooter>
+                  <Button
+                    colorScheme='gray'
+                    mr={3}
+                    onClick={() => setIsLeavingModalOpen(false)}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    colorScheme='red'
+                    onClick={() => {
+                      blocker.proceed?.()
+                      setIsLeavingModalOpen(false)
+                    }}
+                  >
+                    Leave without saving
+                  </Button>
+                </ModalFooter>
+              </ModalContent>
+            </Modal>
+          )}
           <form onSubmit={handleSubmit(onSubmit, onSubmitErrorHandler)}>
-            {isLeavingModalOpen && (
-              <Modal
-                isOpen={isLeavingModalOpen}
-                onClose={() => setIsLeavingModalOpen(false)}
-              >
-                <ModalOverlay />
-                <ModalContent>
-                  <ModalHeader>Are you sure you want to leave?</ModalHeader>
-                  <ModalCloseButton />
-                  <ModalBody>Changes that you made may not be saved.</ModalBody>
-                  <ModalFooter>
-                    <Button
-                      colorScheme='gray'
-                      mr={3}
-                      onClick={() => setIsLeavingModalOpen(false)}
-                    >
-                      Cancel
-                    </Button>
-                    <Button
-                      colorScheme='red'
-                      onClick={() => {
-                        blocker.proceed?.()
-                        setIsLeavingModalOpen(false)
-                      }}
-                    >
-                      Leave without saving
-                    </Button>
-                  </ModalFooter>
-                </ModalContent>
-              </Modal>
-            )}
             <VStack gap='4' mb={12} mt={4} align={'stretch'}>
               {formError && <ApiError error={formError} />}
               {loadedFamily && (


### PR DESCRIPTION
# What's changed

- Driveby add check if dirty to summary field
- Move modal out of form submit context

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
