### PR TITLE
Feature/pdct 1094 move event types into the taxonomy

### DIFF
--- a/src/components/forms/EventForm.tsx
+++ b/src/components/forms/EventForm.tsx
@@ -1,7 +1,14 @@
 import { useEffect, useState } from 'react'
 import { useForm, SubmitHandler, Controller } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
-import { IEvent, IEventFormPost, IError, IEventFormPut } from '@/interfaces'
+import {
+  IEvent,
+  IEventFormPost,
+  IError,
+  IEventFormPut,
+  IConfigTaxonomyCCLW,
+  IConfigTaxonomyUNFCCC,
+} from '@/interfaces'
 import { eventSchema } from '@/schemas/eventSchema'
 import { createEvent, updateEvent } from '@/api/Events'
 
@@ -16,15 +23,14 @@ import {
   useToast,
   Select,
 } from '@chakra-ui/react'
-import useConfig from '@/hooks/useConfig'
 import { ApiError } from '../feedback/ApiError'
-import { FormLoader } from '../feedback/FormLoader'
 import { formatDateISO } from '@/utils/formatDate'
 
 type TProps = {
   familyId: string
   canModify: boolean
   event?: IEvent
+  taxonomy?: IConfigTaxonomyCCLW | IConfigTaxonomyUNFCCC
   onSuccess?: (eventId: string) => void
 }
 
@@ -38,10 +44,10 @@ export const EventForm = ({
   familyId,
   canModify,
   event: loadedEvent,
+  taxonomy,
   onSuccess,
 }: TProps) => {
   const toast = useToast()
-  const { config, loading: configLoading, error: configError } = useConfig()
   const [formError, setFormError] = useState<IError | null | undefined>()
   const {
     register,
@@ -131,8 +137,14 @@ export const EventForm = ({
 
   return (
     <>
-      {configError && <ApiError error={configError} />}
-      {configLoading && <FormLoader />}
+      {!taxonomy && (
+        <ApiError
+          message={'No taxonomy associated with the current family'}
+          detail={
+            'Please go back to the "Families" page, if you think there has been a mistake please contact the administrator.'
+          }
+        />
+      )}
       <form onSubmit={handleSubmit(onSubmit)}>
         <VStack gap='4' mb={12} align={'stretch'}>
           {formError && <ApiError error={formError} />}
@@ -157,7 +169,7 @@ export const EventForm = ({
                   <FormLabel as='legend'>Type</FormLabel>
                   <Select background='white' {...field}>
                     <option value=''>Please select</option>
-                    {config?.event?.types.map((option) => (
+                    {taxonomy?.event_type?.allowed_values.map((option) => (
                       <option key={option} value={option}>
                         {option}
                       </option>

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -192,6 +192,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
       const metadata = familyMetadata as IUNFCCCMetadata
       if (family.author) metadata.author = [family.author]
       if (family.author_type) metadata.author_type = [family.author_type]
+      metadata.event_type = []
       familyMetadata = metadata
     } else if (corpusInfo?.corpus_type == 'Laws and Policies') {
       const metadata: ICCLWMetadata = {
@@ -202,6 +203,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
         framework: family.framework?.map((framework) => framework.value) || [],
         instrument:
           family.instrument?.map((instrument) => instrument.value) || [],
+        event_type: [],
       }
       familyMetadata = metadata
     }
@@ -1029,6 +1031,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                       isSuperUser,
                       userAccess,
                     )}
+                    taxonomy={taxonomy}
                     onSuccess={onEventFormSuccess}
                     event={editingEvent}
                   />

--- a/src/interfaces/Config.ts
+++ b/src/interfaces/Config.ts
@@ -74,7 +74,4 @@ export interface IConfig {
     types: string[]
     variants: string[]
   }
-  event: {
-    types: string[]
-  }
 }

--- a/src/interfaces/Family.ts
+++ b/src/interfaces/Family.ts
@@ -25,6 +25,7 @@ interface IFamilyBase {
 export interface IUNFCCCMetadata {
   author: string[]
   author_type: string[]
+  event_type: string[]
 }
 
 export interface ICCLWMetadata {
@@ -34,6 +35,7 @@ export interface ICCLWMetadata {
   keyword: string[]
   framework: string[]
   instrument: string[]
+  event_type: string[]
 }
 
 export interface IUNFCCCFamily extends IFamilyBase {

--- a/src/interfaces/Family.ts
+++ b/src/interfaces/Family.ts
@@ -22,20 +22,22 @@ interface IFamilyBase {
   last_modified: string
 }
 
-export interface IUNFCCCMetadata {
-  author: string[]
-  author_type: string[]
+export interface IMetadata {
   event_type: string[]
 }
 
-export interface ICCLWMetadata {
+export interface IUNFCCCMetadata extends IMetadata {
+  author: string[]
+  author_type: string[]
+}
+
+export interface ICCLWMetadata extends IMetadata {
   topic: string[]
   hazard: string[]
   sector: string[]
   keyword: string[]
   framework: string[]
   instrument: string[]
-  event_type: string[]
 }
 
 export interface IUNFCCCFamily extends IFamilyBase {

--- a/src/interfaces/Family.ts
+++ b/src/interfaces/Family.ts
@@ -22,16 +22,16 @@ interface IFamilyBase {
   last_modified: string
 }
 
-export interface IMetadata {
+export interface IMetadataBase {
   event_type: string[]
 }
 
-export interface IUNFCCCMetadata extends IMetadata {
+export interface IUNFCCCMetadata extends IMetadataBase {
   author: string[]
   author_type: string[]
 }
 
-export interface ICCLWMetadata extends IMetadata {
+export interface ICCLWMetadata extends IMetadataBase {
   topic: string[]
   hazard: string[]
   sector: string[]

--- a/src/tests/utils/modifyConfig.test.ts
+++ b/src/tests/utils/modifyConfig.test.ts
@@ -71,9 +71,6 @@ describe('modifyConfig', () => {
           }, // TODO
         },
       },
-      event: {
-        types: ['type1', 'type2'],
-      },
     }
 
     const expectedLanguagesSorted = [
@@ -114,9 +111,6 @@ describe('modifyConfig', () => {
           author_type: { allow_blanks: false, allowed_values: [] },
           event_type: { allow_blanks: false, allowed_values: [] },
         },
-      },
-      event: {
-        types: [],
       },
     }
 

--- a/src/tests/utilsTest/mocks.tsx
+++ b/src/tests/utilsTest/mocks.tsx
@@ -85,9 +85,6 @@ const mockConfig = {
     types: ['Type One', 'Type Two'],
     variants: ['Variant One', 'Variant Two'],
   },
-  event: {
-    types: ['Event Type One', 'Event Type Two'],
-  },
 }
 
 const mockUNFCCCFamily: IUNFCCCFamily = {
@@ -112,6 +109,7 @@ const mockUNFCCCFamily: IUNFCCCFamily = {
   metadata: {
     author: ['Author One'],
     author_type: ['Type One'],
+    event_type: [],
   },
 }
 
@@ -141,6 +139,7 @@ const mockCCLWFamily: ICCLWFamily = {
     keyword: ['Keyword One', 'Keyword Two'],
     framework: ['Framework One', 'Framework Two'],
     instrument: ['Instrument One', 'Instrument Two'],
+    event_type: [],
   },
 }
 


### PR DESCRIPTION
# What's changed

- Include event_type in expected CCLW and UNFCCC metadata
- Pass in taxonomy to event form & read event types from there
- Set event_type property on family metadata field to empty array so family create passes

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
