### PR TITLE
Feature/pdct 672 add created and edited columns to document list page

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -20,6 +20,7 @@ lint:
   disabled:
     - hadolint
   enabled:
+    - sort-package-json@2.10.0
     - actionlint@1.6.27
     - checkov@3.2.55
     - eslint@8.57.0

--- a/src/components/lists/DocumentList.tsx
+++ b/src/components/lists/DocumentList.tsx
@@ -17,6 +17,7 @@ import {
   useToast,
   SkeletonText,
   Badge,
+  Flex,
 } from '@chakra-ui/react'
 import { GoPencil } from 'react-icons/go'
 
@@ -27,6 +28,7 @@ import { sortBy } from '@/utils/sortBy'
 import { ArrowDownIcon, ArrowUpIcon, ArrowUpDownIcon } from '@chakra-ui/icons'
 import { getStatusColour } from '@/utils/getStatusColour'
 import { ApiError } from '../feedback/ApiError'
+import { formatDate, formatDateTime } from '@/utils/formatDate'
 
 export default function DocumentList() {
   const [sortControls, setSortControls] = useState<{
@@ -129,6 +131,26 @@ export default function DocumentList() {
                     Title {renderSortIcon('title')}
                   </Th>
                   <Th
+                    onClick={() => handleHeaderClick('last_modified')}
+                    cursor='pointer'
+                  >
+                    <Tooltip placement='top' label='Edited within the system'>
+                      <Flex gap={2} align='center'>
+                        Edited {renderSortIcon('last_modified')}
+                      </Flex>
+                    </Tooltip>
+                  </Th>
+                  <Th
+                    onClick={() => handleHeaderClick('created')}
+                    cursor='pointer'
+                  >
+                    <Tooltip placement='top' label='Date added to system'>
+                      <Flex gap={2} align='center'>
+                        Created {renderSortIcon('created')}
+                      </Flex>
+                    </Tooltip>
+                  </Th>
+                  <Th
                     onClick={() => handleHeaderClick('status')}
                     cursor='pointer'
                   >
@@ -158,6 +180,26 @@ export default function DocumentList() {
                     }
                   >
                     <Td>{document.title}</Td>
+                    <Td>
+                      <Tooltip
+                        placement='top'
+                        label={formatDateTime(document.last_modified)}
+                      >
+                        <Flex gap={2} align='center'>
+                          {formatDate(document.last_modified)}
+                        </Flex>
+                      </Tooltip>
+                    </Td>
+                    <Td>
+                      <Tooltip
+                        placement='top'
+                        label={formatDateTime(document.created)}
+                      >
+                        <Flex gap={2} align='center'>
+                          {formatDate(document.created)}
+                        </Flex>
+                      </Tooltip>
+                    </Td>
                     <Td>
                       <Badge
                         colorScheme={getStatusColour(document.status)}

--- a/src/components/lists/FamilyList.tsx
+++ b/src/components/lists/FamilyList.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useMemo } from 'react'
 import { Link, useLoaderData } from 'react-router-dom'
 import { deleteFamily, getFamilies, TFamilySearchQuery } from '@/api/Families'
 import { IError, TFamily } from '@/interfaces'
-import { formatDate } from '@/utils/formatDate'
+import { formatDate, formatDateTime } from '@/utils/formatDate'
 import {
   Table,
   Thead,
@@ -248,8 +248,27 @@ export default function FamilyList() {
                 <Td>{family.geography}</Td>
                 <Td>{formatDate(family.published_date)}</Td>
                 <Td>{formatDate(family.last_updated_date)}</Td>
-                <Td>{formatDate(family.last_modified)}</Td>
-                <Td>{formatDate(family.created)}</Td>
+                <Td>
+                  <Tooltip
+                    placement='top'
+                    label={formatDateTime(family.last_modified)}
+                  >
+                    <Flex gap={2} align='center'>
+                      {formatDate(family.last_modified)}
+                    </Flex>
+                  </Tooltip>
+                </Td>
+                <Td>
+                  <Tooltip
+                    placement='top'
+                    label={formatDateTime(family.created)}
+                  >
+                    <Flex gap={2} align='center'>
+                      {formatDate(family.created)}
+                    </Flex>
+                  </Tooltip>
+                </Td>
+
                 <Td>
                   <Badge colorScheme={getStatusColour(family.status)} size='sm'>
                     {getStatusAlias(family.status)}

--- a/src/interfaces/Document.ts
+++ b/src/interfaces/Document.ts
@@ -15,6 +15,8 @@ export interface IDocument {
   source_url: string | null
   content_type: string | null
   user_language_name: string | null
+  created: string
+  last_modified: string
 }
 
 export interface IDocumentFormPost {

--- a/src/tests/components/forms/DocumentForm.test.tsx
+++ b/src/tests/components/forms/DocumentForm.test.tsx
@@ -32,6 +32,8 @@ const mockDocument: IDocument = {
   source_url: 'http://example.com/document',
   content_type: 'application/pdf',
   user_language_name: 'Default language',
+  created: '3/1/2021',
+  last_modified: '4/1/2021',
 }
 
 // Tests


### PR DESCRIPTION
# What's changed

- Add created and edited columns to document list page to make it clearer that documents are sorted by edited desc by default

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
