### PR TITLE
Feature/pdct 1138 update shape of document post to include metadata

### DIFF
--- a/src/components/Logout.tsx
+++ b/src/components/Logout.tsx
@@ -8,6 +8,7 @@ export default function Logout() {
   const handleLogout = () => {
     logout()
     navigate('/', { replace: true })
+    navigate(0)
   }
 
   return (

--- a/src/components/forms/DocumentForm.tsx
+++ b/src/components/forms/DocumentForm.tsx
@@ -5,6 +5,7 @@ import {
   IDocument,
   IDocumentFormPost,
   IDocumentFormPostModified,
+  IDocumentMetadata,
   IError,
 } from '@/interfaces'
 import { createDocument, updateDocument } from '@/api/Documents'
@@ -63,8 +64,14 @@ export const DocumentForm = ({
     const convertToModified = (
       data: IDocumentFormPost,
     ): IDocumentFormPostModified => {
+      const metadata: IDocumentMetadata = { role: [] }
+      if (submittedDcumentData.role) {
+        metadata.role = [submittedDcumentData.role]
+      } else metadata.role = []
+
       return {
         ...data,
+        metadata: metadata,
         source_url: submittedDcumentData.source_url || null,
         variant_name: submittedDcumentData.variant_name || null,
         user_language_name:

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -192,7 +192,6 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
       const metadata = familyMetadata as IUNFCCCMetadata
       if (family.author) metadata.author = [family.author]
       if (family.author_type) metadata.author_type = [family.author_type]
-      metadata.event_type = []
       familyMetadata = metadata
     } else if (corpusInfo?.corpus_type == 'Laws and Policies') {
       const metadata: ICCLWMetadata = {
@@ -203,7 +202,6 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
         framework: family.framework?.map((framework) => framework.value) || [],
         instrument:
           family.instrument?.map((instrument) => instrument.value) || [],
-        event_type: [],
       }
       familyMetadata = metadata
     }

--- a/src/interfaces/Document.ts
+++ b/src/interfaces/Document.ts
@@ -34,7 +34,12 @@ export interface IDocumentFormPostModified {
   variant_name?: string | null
   role: string
   type: string
+  metadata: IDocumentMetadata
   title: string
   source_url?: string | null
   user_language_name?: string | null
+}
+
+export interface IDocumentMetadata {
+  role: string[]
 }

--- a/src/interfaces/Event.ts
+++ b/src/interfaces/Event.ts
@@ -21,3 +21,7 @@ export interface IEventFormPut {
   date: Date
   event_type_value: string
 }
+
+export interface IEventMetadata {
+  event_type: string[]
+}

--- a/src/interfaces/Family.ts
+++ b/src/interfaces/Family.ts
@@ -22,16 +22,12 @@ interface IFamilyBase {
   last_modified: string
 }
 
-export interface IMetadataBase {
-  event_type: string[]
-}
-
-export interface IUNFCCCMetadata extends IMetadataBase {
+export interface IUNFCCCMetadata {
   author: string[]
   author_type: string[]
 }
 
-export interface ICCLWMetadata extends IMetadataBase {
+export interface ICCLWMetadata {
   topic: string[]
   hazard: string[]
   sector: string[]

--- a/src/tests/utilsTest/mocks.tsx
+++ b/src/tests/utilsTest/mocks.tsx
@@ -109,7 +109,6 @@ const mockUNFCCCFamily: IUNFCCCFamily = {
   metadata: {
     author: ['Author One'],
     author_type: ['Type One'],
-    event_type: [],
   },
 }
 
@@ -139,7 +138,6 @@ const mockCCLWFamily: ICCLWFamily = {
     keyword: ['Keyword One', 'Keyword Two'],
     framework: ['Framework One', 'Framework Two'],
     instrument: ['Instrument One', 'Instrument Two'],
-    event_type: [],
   },
 }
 


### PR DESCRIPTION
# What's changed

Update shap of the document post form object to include the new metadata field and populate it correctly.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
