### PR TITLE
Feature/pdct 1245 get document role options from taxonomy

### DIFF
--- a/src/components/forms/DocumentForm.tsx
+++ b/src/components/forms/DocumentForm.tsx
@@ -7,6 +7,8 @@ import {
   IDocumentFormPostModified,
   IDocumentMetadata,
   IError,
+  IConfigTaxonomyCCLW,
+  IConfigTaxonomyUNFCCC,
 } from '@/interfaces'
 import { createDocument, updateDocument } from '@/api/Documents'
 import { documentSchema } from '@/schemas/documentSchema'
@@ -35,6 +37,7 @@ type TProps = {
   document?: IDocument
   familyId?: string
   canModify?: boolean
+  taxonomy?: IConfigTaxonomyCCLW | IConfigTaxonomyUNFCCC
   onSuccess?: (documentId: string) => void
 }
 
@@ -42,6 +45,7 @@ export const DocumentForm = ({
   document: loadedDocument,
   familyId,
   canModify,
+  taxonomy,
   onSuccess,
 }: TProps) => {
   const { config, loading: configLoading, error: configError } = useConfig()
@@ -168,6 +172,14 @@ export const DocumentForm = ({
       )}
       {configError && <ApiError error={configError} />}
       {configLoading && <FormLoader />}
+      {!taxonomy && (
+        <ApiError
+          message={'No taxonomy associated with the current family'}
+          detail={
+            'Please go back to the "Families" page, if you think there has been a mistake please contact the administrator.'
+          }
+        />
+      )}
       <form onSubmit={handleSubmit(onSubmit)}>
         <VStack gap='4' mb={12} align={'stretch'}>
           {formError && <ApiError error={formError} />}
@@ -196,7 +208,7 @@ export const DocumentForm = ({
                   <FormLabel as='legend'>Role</FormLabel>
                   <Select background='white' {...field}>
                     <option value=''>Please select</option>
-                    {config?.document?.roles.map((option) => (
+                    {taxonomy?._document?.role?.allowed_values.map((option) => (
                       <option key={option} value={option}>
                         {option}
                       </option>

--- a/src/components/forms/DocumentForm.tsx
+++ b/src/components/forms/DocumentForm.tsx
@@ -60,30 +60,27 @@ export const DocumentForm = ({
   } = useForm({
     resolver: yupResolver(documentSchema),
   })
-  const handleFormSubmission = async (
-    submittedDcumentData: IDocumentFormPost,
-  ) => {
+  const handleFormSubmission = async (formData: IDocumentFormPost) => {
     setFormError(null)
 
     const convertToModified = (
       data: IDocumentFormPost,
     ): IDocumentFormPostModified => {
       const metadata: IDocumentMetadata = { role: [] }
-      if (submittedDcumentData.role) {
-        metadata.role = [submittedDcumentData.role]
+      if (data.role) {
+        metadata.role = [data.role]
       } else metadata.role = []
 
       return {
         ...data,
         metadata: metadata,
-        source_url: submittedDcumentData.source_url || null,
-        variant_name: submittedDcumentData.variant_name || null,
-        user_language_name:
-          submittedDcumentData.user_language_name?.label || null,
+        source_url: data.source_url || null,
+        variant_name: data.variant_name || null,
+        user_language_name: data.user_language_name?.label || null,
       }
     }
 
-    const modifiedDocumentData = convertToModified(submittedDcumentData)
+    const modifiedDocumentData = convertToModified(formData)
 
     if (loadedDocument) {
       return await updateDocument(

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -1008,6 +1008,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                       isSuperUser,
                       userAccess,
                     )}
+                    taxonomy={taxonomy}
                     onSuccess={onDocumentFormSuccess}
                     document={editingDocument}
                   />

--- a/src/interfaces/Config.ts
+++ b/src/interfaces/Config.ts
@@ -54,6 +54,10 @@ export interface IConfigTaxonomyUNFCCC {
 export interface IConfigDocumentMetadata {
   role: IConfigMeta
 }
+export interface IConfigOrganisationMetadata {
+  name: string
+  id: number
+}
 
 export interface IConfigCorpora {
   corpus_import_id: string
@@ -61,6 +65,7 @@ export interface IConfigCorpora {
   description: string
   corpus_type: string
   corpus_type_description: string
+  organisation: IConfigOrganisationMetadata
   taxonomy: IConfigTaxonomyCCLW | IConfigTaxonomyUNFCCC
 }
 
@@ -70,10 +75,6 @@ export interface IConfig {
     [key: string]: string
   }
   languagesSorted: IConfigLanguageSorted[]
-  taxonomies: {
-    CCLW: IConfigTaxonomyCCLW
-    UNFCCC: IConfigTaxonomyUNFCCC
-  }
   corpora: IConfigCorpora[]
   document: {
     roles: string[]

--- a/src/interfaces/Config.ts
+++ b/src/interfaces/Config.ts
@@ -41,12 +41,18 @@ export interface IConfigTaxonomyCCLW {
   framework: IConfigMeta
   instrument: IConfigMeta
   event_type: IConfigMeta
+  _document: IConfigDocumentMetadata
 }
 
 export interface IConfigTaxonomyUNFCCC {
   author: IConfigMeta
   author_type: IConfigMeta
   event_type: IConfigMeta
+  _document: IConfigDocumentMetadata
+}
+
+export interface IConfigDocumentMetadata {
+  role: IConfigMeta
 }
 
 export interface IConfigCorpora {

--- a/src/tests/utils/modifyConfig.test.ts
+++ b/src/tests/utils/modifyConfig.test.ts
@@ -27,50 +27,86 @@ describe('modifyConfig', () => {
         },
       ],
       languagesSorted: [],
-      corpora: [], // TODO
-      taxonomies: {
-        CCLW: {
-          topic: { allow_blanks: false, allowed_values: ['topic1', 'topic2'] },
-          hazard: {
-            allow_blanks: false,
-            allowed_values: ['hazard1', 'hazard2'],
+      corpora: [
+        {
+          corpus_import_id: 'CCLW.corpus.i00000001.n0000',
+          title: 'CCLW national policies',
+          description: 'CCLW national policies',
+          corpus_type: 'Laws and Policies',
+          corpus_type_description: 'Laws and policies',
+          organisation: {
+            name: 'CCLW',
+            id: 1,
           },
-          sector: {
-            allow_blanks: false,
-            allowed_values: ['sector1', 'sector2'],
+          taxonomy: {
+            topic: {
+              allow_blanks: false,
+              allowed_values: ['topic1', 'topic2'],
+            },
+            hazard: {
+              allow_blanks: false,
+              allowed_values: ['hazard1', 'hazard2'],
+            },
+            sector: {
+              allow_blanks: false,
+              allowed_values: ['sector1', 'sector2'],
+            },
+            keyword: {
+              allow_blanks: false,
+              allowed_values: ['keyword1', 'keyword2'],
+            },
+            framework: {
+              allow_blanks: false,
+              allowed_values: ['framework1', 'framework2'],
+            },
+            instrument: {
+              allow_blanks: false,
+              allowed_values: ['instrument1', 'instrument2'],
+            },
+            event_type: {
+              allow_blanks: false,
+              allowed_values: ['eventType1', 'eventType2'],
+            },
+            _document: {
+              role: {
+                allow_blanks: false,
+                allowed_values: ['role1', 'role2'],
+              },
+            },
           },
-          keyword: {
-            allow_blanks: false,
-            allowed_values: ['keyword1', 'keyword2'],
-          },
-          framework: {
-            allow_blanks: false,
-            allowed_values: ['framework1', 'framework2'],
-          },
-          instrument: {
-            allow_blanks: false,
-            allowed_values: ['instrument1', 'instrument2'],
-          },
-          event_type: {
-            allow_blanks: false,
-            allowed_values: ['eventType1', 'eventType2'],
-          }, // TODO
         },
-        UNFCCC: {
-          author: {
-            allow_blanks: false,
-            allowed_values: ['author1', 'author2'],
+        {
+          corpus_import_id: 'UNFCCC.corpus.i00000001.n0000',
+          title: 'UNFCCC Submissions',
+          description: 'UNFCCC Submissions',
+          corpus_type: 'Intl. agreements',
+          corpus_type_description: 'Intl. agreements',
+          organisation: {
+            name: 'UNFCCC',
+            id: 3,
           },
-          author_type: {
-            allow_blanks: false,
-            allowed_values: ['authorType1', 'authorType2'],
+          taxonomy: {
+            author: {
+              allow_blanks: false,
+              allowed_values: ['author1', 'author2'],
+            },
+            author_type: {
+              allow_blanks: false,
+              allowed_values: ['authorType1', 'authorType2'],
+            },
+            event_type: {
+              allow_blanks: false,
+              allowed_values: ['eventType1', 'eventType2'],
+            },
+            _document: {
+              role: {
+                allow_blanks: false,
+                allowed_values: ['role1', 'role2'],
+              },
+            },
           },
-          event_type: {
-            allow_blanks: false,
-            allowed_values: ['eventType1', 'eventType2'],
-          }, // TODO
         },
-      },
+      ],
     }
 
     const expectedLanguagesSorted = [
@@ -96,22 +132,6 @@ describe('modifyConfig', () => {
       geographies: [],
       languagesSorted: [],
       corpora: [],
-      taxonomies: {
-        CCLW: {
-          topic: { allow_blanks: false, allowed_values: [] },
-          hazard: { allow_blanks: false, allowed_values: [] },
-          sector: { allow_blanks: false, allowed_values: [] },
-          keyword: { allow_blanks: false, allowed_values: [] },
-          framework: { allow_blanks: false, allowed_values: [] },
-          instrument: { allow_blanks: false, allowed_values: [] },
-          event_type: { allow_blanks: false, allowed_values: [] },
-        },
-        UNFCCC: {
-          author: { allow_blanks: false, allowed_values: [] },
-          author_type: { allow_blanks: false, allowed_values: [] },
-          event_type: { allow_blanks: false, allowed_values: [] },
-        },
-      },
     }
 
     const modifiedConfig = modifyConfig(mockConfig)

--- a/src/tests/utilsTest/mocks.tsx
+++ b/src/tests/utilsTest/mocks.tsx
@@ -24,62 +24,6 @@ const mockConfig = {
     { value: 'es', label: 'Spanish' },
   ],
   corpora: [],
-  taxonomies: {
-    CCLW: {
-      topic: {
-        allow_any: false,
-        allow_blanks: false,
-        allowed_values: ['Topic One', 'Topic Two'],
-      },
-      hazard: {
-        allow_any: false,
-        allow_blanks: false,
-        allowed_values: ['Hazard One', 'Hazard Two'],
-      },
-      sector: {
-        allow_any: false,
-        allow_blanks: false,
-        allowed_values: ['Sector One', 'Sector Two'],
-      },
-      keyword: {
-        allow_any: false,
-        allow_blanks: false,
-        allowed_values: ['Keyword One', 'Keyword Two'],
-      },
-      framework: {
-        allow_any: false,
-        allow_blanks: false,
-        allowed_values: ['Framework One', 'Framework Two'],
-      },
-      instrument: {
-        allow_any: false,
-        allow_blanks: false,
-        allowed_values: ['Instrument One', 'Instrument Two'],
-      },
-      event_type: {
-        allow_any: false,
-        allow_blanks: false,
-        allowed_values: ['Event One', 'Event Two'],
-      },
-    },
-    UNFCCC: {
-      author: {
-        allow_any: false,
-        allow_blanks: false,
-        allowed_values: ['Author One', 'Author Two'],
-      },
-      author_type: {
-        allow_any: false,
-        allow_blanks: false,
-        allowed_values: ['Type One', 'Type Two'],
-      },
-      event_type: {
-        allow_any: false,
-        allow_blanks: false,
-        allowed_values: ['Event One', 'Event Two'],
-      },
-    },
-  },
   document: {
     roles: ['Role One', 'Role Two'],
     types: ['Type One', 'Type Two'],
@@ -198,6 +142,10 @@ const mockCCLWConfig: IConfig = {
       description: 'UNFCCC Submissions',
       corpus_type: 'CCLW national policies',
       corpus_type_description: 'Laws and Policies',
+      organisation: {
+        name: 'CCLW',
+        id: 1,
+      },
       taxonomy: {
         topic: {
           allow_any: false,
@@ -234,6 +182,13 @@ const mockCCLWConfig: IConfig = {
           allow_blanks: false,
           allowed_values: ['Event One', 'Event Two'],
         },
+        _document: {
+          role: {
+            allow_any: false,
+            allow_blanks: false,
+            allowed_values: ['Role One', 'Role Two'],
+          },
+        },
       },
     },
   ],
@@ -248,6 +203,10 @@ const mockUNFCCCConfig: IConfig = {
       description: 'UNFCCC Submissions',
       corpus_type: 'Intl. agreements',
       corpus_type_description: 'Intl. agreements',
+      organisation: {
+        name: 'UNFCCC',
+        id: 3,
+      },
       taxonomy: {
         author: {
           allow_any: false,
@@ -263,6 +222,13 @@ const mockUNFCCCConfig: IConfig = {
           allow_any: false,
           allow_blanks: false,
           allowed_values: ['Event One', 'Event Two'],
+        },
+        _document: {
+          role: {
+            allow_any: false,
+            allow_blanks: false,
+            allowed_values: ['Role One', 'Role Two'],
+          },
         },
       },
     },


### PR DESCRIPTION
# What's changed

- Get document role options from taxonomy instead of config endpoint
- Remove assumption between one org and one corpus
- Rename variables in DocumentForm for better visibility
- Fix config tests

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
