### PR TITLE
Feature/pdct 1095 move document type to taxonomy

### DIFF
--- a/src/components/forms/DocumentForm.tsx
+++ b/src/components/forms/DocumentForm.tsx
@@ -148,10 +148,7 @@ export const DocumentForm = ({
       reset({
         family_import_id: loadedDocument.family_import_id,
         variant_name: loadedDocument.variant_name ?? '',
-        role:
-          'role' in loadedDocument.metadata
-            ? loadedDocument.metadata.role[0]
-            : '',
+        role: loadedDocument?.metadata?.role[0] ?? '',
         type: loadedDocument.type ?? '',
         title: loadedDocument.title,
         source_url: loadedDocument.source_url ?? '',

--- a/src/components/forms/DocumentForm.tsx
+++ b/src/components/forms/DocumentForm.tsx
@@ -78,8 +78,6 @@ export const DocumentForm = ({
         metadata.type = [data.type]
       }
 
-      console.log(metadata)
-
       return {
         family_import_id: data.family_import_id,
         type: data.type,

--- a/src/components/forms/DocumentForm.tsx
+++ b/src/components/forms/DocumentForm.tsx
@@ -70,10 +70,15 @@ export const DocumentForm = ({
     const convertToModified = (
       data: IDocumentFormPost,
     ): IDocumentFormPostModified => {
-      const metadata: IDocumentMetadata = { role: [] }
+      const metadata: IDocumentMetadata = { role: [], type: [] }
       if (data.role) {
         metadata.role = [data.role]
-      } else metadata.role = []
+      }
+      if (data.type) {
+        metadata.type = [data.type]
+      }
+
+      console.log(metadata)
 
       return {
         family_import_id: data.family_import_id,

--- a/src/interfaces/Document.ts
+++ b/src/interfaces/Document.ts
@@ -41,4 +41,5 @@ export interface IDocumentFormPostModified {
 
 export interface IDocumentMetadata {
   role: string[]
+  type: string[]
 }

--- a/src/tests/components/forms/DocumentForm.test.tsx
+++ b/src/tests/components/forms/DocumentForm.test.tsx
@@ -23,7 +23,7 @@ const mockDocument: IDocument = {
   variant_name: 'Variant Name',
   status: 'Active',
   type: 'PDF',
-  metadata: { role: ['Editor'] },
+  metadata: { role: ['Editor'], type: ['PDF'] },
   slug: 'document-slug',
   physical_id: 101,
   title: 'Sample Document Title',


### PR DESCRIPTION
# What's changed

- Add type to document metadata

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
