### PR TITLE
Remove references to document type on DTO

### DIFF
--- a/src/components/family/FamilyDocument.tsx
+++ b/src/components/family/FamilyDocument.tsx
@@ -62,7 +62,9 @@ export const FamilyDocument = ({
           {document?.metadata?.role && (
             <Text>Role: {document.metadata.role}</Text>
           )}
-          {document?.type && <Text>Type: {document.type}</Text>}
+          {document?.metadata?.type && (
+            <Text>Type: {document.metadata.type}</Text>
+          )}
           {document?.variant_name && (
             <Text>Variant: {document.variant_name}</Text>
           )}

--- a/src/components/forms/DocumentForm.tsx
+++ b/src/components/forms/DocumentForm.tsx
@@ -80,7 +80,6 @@ export const DocumentForm = ({
 
       return {
         family_import_id: data.family_import_id,
-        type: data.type,
         title: data.title,
         metadata: metadata,
         source_url: data.source_url || null,

--- a/src/interfaces/Document.ts
+++ b/src/interfaces/Document.ts
@@ -5,7 +5,6 @@ export interface IDocument {
   family_import_id: string
   variant_name: string | null
   status: string
-  type: string | null
   slug: string
   metadata: IDocumentMetadata
   physical_id: number
@@ -32,7 +31,6 @@ export interface IDocumentFormPost {
 export interface IDocumentFormPostModified {
   family_import_id: string
   variant_name?: string | null
-  type: string
   metadata: IDocumentMetadata
   title: string
   source_url?: string | null

--- a/src/tests/components/forms/DocumentForm.test.tsx
+++ b/src/tests/components/forms/DocumentForm.test.tsx
@@ -22,7 +22,6 @@ const mockDocument: IDocument = {
   family_import_id: '67890',
   variant_name: 'Variant Name',
   status: 'Active',
-  type: 'PDF',
   metadata: { role: ['Editor'], type: ['PDF'] },
   slug: 'document-slug',
   physical_id: 101,


### PR DESCRIPTION
# What's changed

- Remove references to document type on DTO

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
