### PR TITLE
Bug/pdct 1271 display doc role and type on doc edit page

### DIFF
--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -17,6 +17,7 @@ import {
   IConfigTaxonomyUNFCCC,
   IConfigTaxonomyCCLW,
   IDecodedToken,
+  IConfigCorpora,
 } from '@/interfaces'
 import { createFamily, updateFamily } from '@/api/Families'
 import { deleteDocument } from '@/api/Documents'
@@ -72,6 +73,7 @@ import { chakraStylesSelect } from '@/styles/chakra'
 import { WarningIcon } from '@chakra-ui/icons'
 import { FamilyEventList } from '../lists/FamilyEventList'
 import { EventEditDrawer } from '../drawers/EventEditDrawer'
+import useCorpus from '@/hooks/useCorpus'
 
 type TMultiSelect = {
   value: string
@@ -139,21 +141,11 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
   const [familyEvents, setFamilyEvents] = useState<string[]>([])
 
   const watchCorpus = watch('corpus')
-  const corpusInfo = useMemo(() => {
-    const getCorpusFromId = (corpusId: string) => {
-      const corp = config?.corpora.find(
-        (corpus) => corpus.corpus_import_id === corpusId,
-      )
-      return corp ? corp : null
-    }
-
-    if (loadedFamily) {
-      return getCorpusFromId(loadedFamily?.corpus_import_id)
-    } else if (watchCorpus) {
-      return getCorpusFromId(watchCorpus?.value)
-    }
-    return null
-  }, [config?.corpora, loadedFamily, watchCorpus])
+  const corpusInfo = useCorpus(
+    config?.corpora,
+    loadedFamily?.corpus_import_id,
+    watchCorpus?.value,
+  ) as IConfigCorpora
 
   const corpusTitle = loadedFamily
     ? loadedFamily?.corpus_title

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -17,7 +17,6 @@ import {
   IConfigTaxonomyUNFCCC,
   IConfigTaxonomyCCLW,
   IDecodedToken,
-  IConfigCorpora,
 } from '@/interfaces'
 import { createFamily, updateFamily } from '@/api/Families'
 import { deleteDocument } from '@/api/Documents'
@@ -74,6 +73,7 @@ import { WarningIcon } from '@chakra-ui/icons'
 import { FamilyEventList } from '../lists/FamilyEventList'
 import { EventEditDrawer } from '../drawers/EventEditDrawer'
 import useCorpus from '@/hooks/useCorpus'
+import useTaxonomy from '@/hooks/useTaxonomy'
 
 type TMultiSelect = {
   value: string
@@ -145,19 +145,13 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
     config?.corpora,
     loadedFamily?.corpus_import_id,
     watchCorpus?.value,
-  ) as IConfigCorpora
+  )
 
   const corpusTitle = loadedFamily
     ? loadedFamily?.corpus_title
     : corpusInfo?.title
 
-  const taxonomy = useMemo(() => {
-    if (corpusInfo?.corpus_type === 'Law and Policies')
-      return corpusInfo?.taxonomy as IConfigTaxonomyCCLW
-    else if (corpusInfo?.corpus_type === 'Intl. agreements')
-      return corpusInfo?.taxonomy as IConfigTaxonomyUNFCCC
-    else return corpusInfo?.taxonomy
-  }, [corpusInfo])
+  const taxonomy = useTaxonomy(corpusInfo?.corpus_type, corpusInfo?.taxonomy)
 
   const userToken = useMemo(() => {
     const token = localStorage.getItem('token')

--- a/src/hooks/useCorpus.ts
+++ b/src/hooks/useCorpus.ts
@@ -6,7 +6,7 @@ const useCorpus = (
   corpus_id?: string,
   watchCorpusValue?: string,
 ) => {
-  return useMemo<IConfigCorpora | null>(() => {
+  return useMemo(() => {
     const getCorpusFromId = (corpusId?: string) => {
       const corp = corpora?.find(
         (corpus) => corpus.corpus_import_id === corpusId,

--- a/src/hooks/useCorpus.ts
+++ b/src/hooks/useCorpus.ts
@@ -1,0 +1,21 @@
+import { IConfigCorpora } from '@/interfaces'
+import { useMemo } from 'react'
+
+const useCorpus = (
+  corpora?: IConfigCorpora[],
+  corpus_id?: string,
+  watchCorpusValue?: string,
+) => {
+  return useMemo<IConfigCorpora | null>(() => {
+    const getCorpusFromId = (corpusId?: string) => {
+      const corp = corpora?.find(
+        (corpus) => corpus.corpus_import_id === corpusId,
+      )
+      return corp ? corp : null
+    }
+
+    return getCorpusFromId(corpus_id ? corpus_id : watchCorpusValue)
+  }, [corpora, corpus_id, watchCorpusValue])
+}
+
+export default useCorpus

--- a/src/hooks/useTaxonomy.ts
+++ b/src/hooks/useTaxonomy.ts
@@ -1,0 +1,17 @@
+import { IConfigTaxonomyCCLW, IConfigTaxonomyUNFCCC } from '@/interfaces/Config'
+import { useMemo } from 'react'
+
+const useTaxonomy = (
+  corpus_type?: string,
+  corpus_taxonomy?: IConfigTaxonomyCCLW | IConfigTaxonomyUNFCCC,
+) => {
+  return useMemo(() => {
+    if (corpus_type === 'Law and Policies')
+      return corpus_taxonomy as IConfigTaxonomyCCLW
+    else if (corpus_type === 'Intl. agreements')
+      return corpus_taxonomy as IConfigTaxonomyUNFCCC
+    else return corpus_taxonomy
+  }, [corpus_type, corpus_taxonomy])
+}
+
+export default useTaxonomy

--- a/src/views/document/Document.tsx
+++ b/src/views/document/Document.tsx
@@ -12,10 +12,21 @@ import { Loader } from '@/components/Loader'
 import { DocumentForm } from '@/components/forms/DocumentForm'
 import { ArrowBackIcon } from '@chakra-ui/icons'
 import { ApiError } from '@/components/feedback/ApiError'
+import useFamily from '@/hooks/useFamily'
+import useCorpus from '@/hooks/useCorpus'
+import useConfig from '@/hooks/useConfig'
+import useTaxonomy from '@/hooks/useTaxonomy'
 
-export default function Collection() {
+export default function Document() {
   const { importId } = useParams()
   const { document, loading, error } = useDocument(importId)
+  const { config } = useConfig()
+  const { family } = useFamily(document?.family_import_id)
+  const corpusInfo = useCorpus(config?.corpora, family?.corpus_import_id)
+  const taxonomy = useTaxonomy(corpusInfo?.corpus_type, corpusInfo?.taxonomy)
+  console.log('family: ', family)
+  console.log('corpusInfo: ', corpusInfo)
+  console.log('taxonomy: ', taxonomy)
 
   const canLoadForm = !loading && !error
   const pageTitle = loading
@@ -65,7 +76,9 @@ export default function Collection() {
             </Box>
           </>
         )}
-        {canLoadForm && <DocumentForm document={document ?? undefined} />}
+        {canLoadForm && (
+          <DocumentForm document={document ?? undefined} taxonomy={taxonomy} />
+        )}
       </Box>
     </>
   )

--- a/src/views/document/Document.tsx
+++ b/src/views/document/Document.tsx
@@ -20,17 +20,28 @@ import useTaxonomy from '@/hooks/useTaxonomy'
 export default function Document() {
   const { importId } = useParams()
   const { document, loading, error } = useDocument(importId)
-  const { config } = useConfig()
-  const { family } = useFamily(document?.family_import_id)
+  const { config, loading: configLoading, error: configError } = useConfig()
+  const {
+    family,
+    loading: familyLoading,
+    error: familyError,
+  } = useFamily(document?.family_import_id)
   const corpusInfo = useCorpus(config?.corpora, family?.corpus_import_id)
   const taxonomy = useTaxonomy(corpusInfo?.corpus_type, corpusInfo?.taxonomy)
 
-  const canLoadForm = !loading && !error
-  const pageTitle = loading
-    ? 'Loading...'
-    : document
-      ? `Editing: ${document.title}`
-      : 'Create new document'
+  const canLoadForm =
+    !loading &&
+    !configLoading &&
+    !familyLoading &&
+    !error &&
+    !configError &&
+    !familyError
+  const pageTitle =
+    loading || familyLoading || configLoading
+      ? 'Loading...'
+      : document
+        ? `Editing: ${document.title}`
+        : 'Create new document'
 
   return (
     <>

--- a/src/views/document/Document.tsx
+++ b/src/views/document/Document.tsx
@@ -24,9 +24,6 @@ export default function Document() {
   const { family } = useFamily(document?.family_import_id)
   const corpusInfo = useCorpus(config?.corpora, family?.corpus_import_id)
   const taxonomy = useTaxonomy(corpusInfo?.corpus_type, corpusInfo?.taxonomy)
-  console.log('family: ', family)
-  console.log('corpusInfo: ', corpusInfo)
-  console.log('taxonomy: ', taxonomy)
 
   const canLoadForm = !loading && !error
   const pageTitle = loading


### PR DESCRIPTION
# What's changed

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
