### PR TITLE
Revert the change to the WYSIWYG stripPastedStyles

### DIFF
--- a/src/components/form-components/WYSIWYG.tsx
+++ b/src/components/form-components/WYSIWYG.tsx
@@ -50,7 +50,6 @@ export const WYSIWYG = ({ html = DEFAULT_HTML, onChange }: TProps) => {
             toolbar={{
               options: ['inline', 'list'],
             }}
-            stripPastedStyles
           />
         </CardBody>
       </Card>


### PR DESCRIPTION
# What's changed
- Revert the change to the WYSIWYG and remove the stripPastedStyles prop

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
