### PR TITLE
ci: Reduce reviewers scope

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,4 +12,4 @@
 # review when someone opens a pull request. Teams should
 # be identified in the format @org/team-name. Teams must have
 # explicit write access to the repository.
-* @climatepolicyradar/tech-devs
+* @climatepolicyradar/software


### PR DESCRIPTION
# What's changed

From a discussion in the product<>engineering retro today. The `tech-devs` team is quite broad, and ends up with people receiving a lot of emails.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
