### PR TITLE
Bug/pdct 1143 update event list

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "eslint-plugin-react": "^7.34.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.1",
+    "jwt-encode": "^1.0.1",
     "markdownlint-cli": "^0.37.0",
     "prettier": "^3.1.0",
     "react-icons": "^4.10.1",

--- a/src/components/family/FamilyEvent.tsx
+++ b/src/components/family/FamilyEvent.tsx
@@ -13,12 +13,15 @@ import { ApiError } from '../feedback/ApiError'
 import { DeleteButton } from '../buttons/Delete'
 import { formatDate } from '@/utils/formatDate'
 import { IEvent } from '@/interfaces'
+import { useEffect } from 'react'
 
 type TProps = {
   eventId: string
   canModify: boolean
   onEditClick?: (event: IEvent) => void
   onDeleteClick?: (eventId: string) => void
+  updateEvent: boolean
+  setUpdateEvent: (updateEvent: boolean) => void
 }
 
 export const FamilyEvent = ({
@@ -26,8 +29,17 @@ export const FamilyEvent = ({
   canModify,
   onEditClick,
   onDeleteClick,
+  updateEvent,
+  setUpdateEvent,
 }: TProps) => {
-  const { event, loading, error } = useEvent(eventId)
+  const { event, loading, error, reload } = useEvent(eventId)
+
+  useEffect(() => {
+    if (updateEvent) {
+      reload()
+      setUpdateEvent(false)
+    }
+  }, [updateEvent, setUpdateEvent, reload])
 
   const handleEditClick = () => {
     onEditClick && event ? onEditClick(event) : null

--- a/src/components/family/FamilyEvent.tsx
+++ b/src/components/family/FamilyEvent.tsx
@@ -20,8 +20,8 @@ type TProps = {
   canModify: boolean
   onEditClick?: (event: IEvent) => void
   onDeleteClick?: (eventId: string) => void
-  updateEvent: boolean
-  setUpdateEvent: (updateEvent: boolean) => void
+  updatedEvent: string
+  setUpdatedEvent: (updateEvent: string) => void
 }
 
 export const FamilyEvent = ({
@@ -29,17 +29,17 @@ export const FamilyEvent = ({
   canModify,
   onEditClick,
   onDeleteClick,
-  updateEvent,
-  setUpdateEvent,
+  updatedEvent,
+  setUpdatedEvent,
 }: TProps) => {
   const { event, loading, error, reload } = useEvent(eventId)
 
   useEffect(() => {
-    if (updateEvent) {
+    if (updatedEvent === eventId) {
       reload()
-      setUpdateEvent(false)
+      setUpdatedEvent('')
     }
-  }, [updateEvent, setUpdateEvent, reload])
+  }, [updatedEvent, setUpdatedEvent, reload, eventId])
 
   const handleEditClick = () => {
     onEditClick && event ? onEditClick(event) : null

--- a/src/components/family/FamilyEvent.tsx
+++ b/src/components/family/FamilyEvent.tsx
@@ -67,7 +67,7 @@ export const FamilyEvent = ({
               <Button
                 size='sm'
                 onClick={handleEditClick}
-                data-test-id={`edit-event-${eventId}`}
+                data-testid={`edit-${eventId}`}
               >
                 Edit
               </Button>

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -139,6 +139,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
   >()
   const [familyDocuments, setFamilyDocuments] = useState<string[]>([])
   const [familyEvents, setFamilyEvents] = useState<string[]>([])
+  const [updateEvent, setUpdateEvent] = useState<boolean>(false)
 
   const watchCorpus = watch('corpus')
   const corpusInfo = useCorpus(
@@ -323,6 +324,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
     onClose()
     if (familyEvents.includes(eventId)) setFamilyEvents([...familyEvents])
     else setFamilyEvents([...familyEvents, eventId])
+    setUpdateEvent(true)
   }
 
   const canLoadForm =
@@ -883,6 +885,8 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                 onAddNewEntityClick={onAddNewEntityClick}
                 setFamilyEvents={setFamilyEvents}
                 loadedFamily={loadedFamily}
+                updateEvent={updateEvent}
+                setUpdateEvent={setUpdateEvent}
               />
             </VStack>
             <ButtonGroup

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -139,7 +139,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
   >()
   const [familyDocuments, setFamilyDocuments] = useState<string[]>([])
   const [familyEvents, setFamilyEvents] = useState<string[]>([])
-  const [updateEvent, setUpdateEvent] = useState<boolean>(false)
+  const [updatedEvent, setUpdatedEvent] = useState<string>('')
 
   const watchCorpus = watch('corpus')
   const corpusInfo = useCorpus(
@@ -324,7 +324,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
     onClose()
     if (familyEvents.includes(eventId)) setFamilyEvents([...familyEvents])
     else setFamilyEvents([...familyEvents, eventId])
-    setUpdateEvent(true)
+    setUpdatedEvent(eventId)
   }
 
   const canLoadForm =
@@ -885,8 +885,8 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                 onAddNewEntityClick={onAddNewEntityClick}
                 setFamilyEvents={setFamilyEvents}
                 loadedFamily={loadedFamily}
-                updateEvent={updateEvent}
-                setUpdateEvent={setUpdateEvent}
+                updatedEvent={updatedEvent}
+                setUpdatedEvent={setUpdatedEvent}
               />
             </VStack>
             <ButtonGroup

--- a/src/components/lists/FamilyEventList.tsx
+++ b/src/components/lists/FamilyEventList.tsx
@@ -20,8 +20,8 @@ type TProps = {
   onAddNewEntityClick: (entityType: TChildEntity) => void
   setFamilyEvents: (events: string[]) => void
   loadedFamily?: TFamily
-  updateEvent: boolean
-  setUpdateEvent: (updateEvent: boolean) => void
+  updatedEvent: string
+  setUpdatedEvent: (updateEvent: string) => void
 }
 
 export const FamilyEventList = ({
@@ -31,8 +31,8 @@ export const FamilyEventList = ({
   onAddNewEntityClick,
   setFamilyEvents,
   loadedFamily,
-  updateEvent,
-  setUpdateEvent,
+  updatedEvent,
+  setUpdatedEvent,
 }: TProps) => {
   const toast = useToast()
 
@@ -88,8 +88,8 @@ export const FamilyEventList = ({
               key={familyEvent}
               onEditClick={(event) => onEditEntityClick('event', event)}
               onDeleteClick={onEventDeleteClick}
-              updateEvent={updateEvent}
-              setUpdateEvent={setUpdateEvent}
+              updatedEvent={updatedEvent}
+              setUpdatedEvent={setUpdatedEvent}
             />
           ))}
         </Flex>

--- a/src/components/lists/FamilyEventList.tsx
+++ b/src/components/lists/FamilyEventList.tsx
@@ -20,6 +20,8 @@ type TProps = {
   onAddNewEntityClick: (entityType: TChildEntity) => void
   setFamilyEvents: (events: string[]) => void
   loadedFamily?: TFamily
+  updateEvent: boolean
+  setUpdateEvent: (updateEvent: boolean) => void
 }
 
 export const FamilyEventList = ({
@@ -29,6 +31,8 @@ export const FamilyEventList = ({
   onAddNewEntityClick,
   setFamilyEvents,
   loadedFamily,
+  updateEvent,
+  setUpdateEvent,
 }: TProps) => {
   const toast = useToast()
 
@@ -84,6 +88,8 @@ export const FamilyEventList = ({
               key={familyEvent}
               onEditClick={(event) => onEditEntityClick('event', event)}
               onDeleteClick={onEventDeleteClick}
+              updateEvent={updateEvent}
+              setUpdateEvent={setUpdateEvent}
             />
           ))}
         </Flex>

--- a/src/routes/familyRoutes.tsx
+++ b/src/routes/familyRoutes.tsx
@@ -1,0 +1,32 @@
+import FamilyList, {
+  loader as familiesLoader,
+} from '@/components/lists/FamilyList'
+import ErrorPage from '@/views/Error'
+import Families from '@/views/family/Families'
+import Family from '@/views/family/Family'
+
+export const familyRoutes = [
+  {
+    path: '/family/new',
+    element: <Family />,
+    errorElement: <ErrorPage />,
+  },
+  {
+    path: 'family/:importId/edit',
+    element: <Family />,
+    errorElement: <ErrorPage />,
+  },
+  {
+    path: 'families',
+    element: <Families />,
+    errorElement: <ErrorPage />,
+    children: [
+      {
+        path: '',
+        element: <FamilyList />,
+        loader: familiesLoader,
+        errorElement: <ErrorPage />,
+      },
+    ],
+  },
+]

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -7,17 +7,13 @@ import Root from '@/Root'
 import Login from '@/views/auth/Login'
 import Dashboard from '@/views/dashboard/Dashboard'
 import ErrorPage from '@views/Error'
-import Family from '@/views/family/Family'
-import Families from '@/views/family/Families'
-import FamilyList, {
-  loader as familiesLoader,
-} from '@/components/lists/FamilyList'
 import Collections from '@/views/collection/Collections'
 import CollectionList from '@/components/lists/CollectionList'
 import Collection from '@/views/collection/Collection'
 import Documents from '@/views/document/Documents'
 import DocumentList from '@/components/lists/DocumentList'
 import Document from '@/views/document/Document'
+import { familyRoutes } from './familyRoutes'
 
 const authenticatedRoutes = [
   {
@@ -37,29 +33,7 @@ const authenticatedRoutes = [
                 element: <Dashboard />,
                 errorElement: <ErrorPage />,
               },
-              {
-                path: '/family/new',
-                element: <Family />,
-                errorElement: <ErrorPage />,
-              },
-              {
-                path: 'family/:importId/edit',
-                element: <Family />,
-                errorElement: <ErrorPage />,
-              },
-              {
-                path: 'families',
-                element: <Families />,
-                errorElement: <ErrorPage />,
-                children: [
-                  {
-                    path: '',
-                    element: <FamilyList />,
-                    loader: familiesLoader,
-                    errorElement: <ErrorPage />,
-                  },
-                ],
-              },
+              ...familyRoutes,
               {
                 path: '/collection/new',
                 element: <Collection />,

--- a/src/tests/components/forms/FamilyForm.test.tsx
+++ b/src/tests/components/forms/FamilyForm.test.tsx
@@ -80,6 +80,7 @@ describe('FamilyForm', () => {
   afterEach(cleanup)
 
   it('warns when no access', async () => {
+    localStorage.clear()
     const testFamily = mockFamiliesData[1]
     renderComponent(testFamily)
     await flushPromises()

--- a/src/tests/components/lists/FamilyEventList.test.tsx
+++ b/src/tests/components/lists/FamilyEventList.test.tsx
@@ -24,8 +24,8 @@ describe('FamilyEventList', () => {
         onAddNewEntityClick={() => {}}
         setFamilyEvents={() => {}}
         loadedFamily={mockFamiliesData[0]}
-        updateEvent={false}
-        setUpdateEvent={() => {}}
+        updatedEvent={''}
+        setUpdatedEvent={() => {}}
       />,
     )
 

--- a/src/tests/components/lists/FamilyEventList.test.tsx
+++ b/src/tests/components/lists/FamilyEventList.test.tsx
@@ -24,6 +24,8 @@ describe('FamilyEventList', () => {
         onAddNewEntityClick={() => {}}
         setFamilyEvents={() => {}}
         loadedFamily={mockFamiliesData[0]}
+        updateEvent={false}
+        setUpdateEvent={() => {}}
       />,
     )
 

--- a/src/tests/components/lists/FamilyList.test.tsx
+++ b/src/tests/components/lists/FamilyList.test.tsx
@@ -6,11 +6,6 @@ import { formatDate } from '@/utils/formatDate'
 import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom'
 
-vi.mock('@/api/Families', () => ({
-  getFamilies: vi.fn(),
-  deleteFamily: vi.fn(),
-}))
-
 vi.mock('react-router-dom', async (importOriginal) => {
   const actual: unknown = await importOriginal()
   return {

--- a/src/tests/mocks/handlers.ts
+++ b/src/tests/mocks/handlers.ts
@@ -2,10 +2,9 @@ import { http, HttpResponse } from 'msw'
 import {
   cclwConfigMock,
   mockCCLWFamilyWithOneEvent,
-  mockEvent,
   mockFamiliesData,
 } from '../utilsTest/mocks'
-import { updateEvent } from './repository'
+import { getEvent, updateEvent } from './repository'
 import { IEvent } from '@/interfaces/Event'
 
 export const handlers = [
@@ -35,13 +34,16 @@ export const handlers = [
     return HttpResponse.json([])
   }),
 
-  http.get('*/v1/events/:id', () => {
-    return HttpResponse.json({ ...mockEvent })
+  http.get('*/v1/events/:id', ({ params }) => {
+    const { id } = params
+    const event = getEvent(id as string)
+    return HttpResponse.json(event)
   }),
   http.put('*/v1/events/:id', async ({ request, params }) => {
     const { id } = params
     const updateData = await request.json()
     updateEvent(updateData as IEvent, id as string)
-    return HttpResponse.json({ ...mockEvent })
+    const updatedEvent = getEvent(id as string)
+    return HttpResponse.json(updatedEvent)
   }),
 ]

--- a/src/tests/mocks/handlers.ts
+++ b/src/tests/mocks/handlers.ts
@@ -1,9 +1,47 @@
-import { http } from 'msw'
+import { http, HttpResponse } from 'msw'
+import {
+  cclwConfigMock,
+  mockCCLWFamilyWithOneEvent,
+  mockEvent,
+  mockFamiliesData,
+} from '../utilsTest/mocks'
+import { updateEvent } from './repository'
+import { IEvent } from '@/interfaces/Event'
 
 export const handlers = [
-  // Intercept "GET https://example.com/user" requests...
-  http.get(
-    'https://admin.dev.climatepolicyradar.org/api/v1/events/*',
-    () => {},
-  ),
+  http.get('*/v1/config', () => {
+    return HttpResponse.json({ ...cclwConfigMock })
+  }),
+
+  http.get('*/v1/families/:id', ({ params }) => {
+    const { id } = params
+    if (id === 'mockCCLWFamilyWithOneEvent') {
+      return HttpResponse.json({ ...mockCCLWFamilyWithOneEvent })
+    }
+    return HttpResponse.json({ ...mockFamiliesData[0] })
+  }),
+  http.get('*/v1/families/', () => {
+    return HttpResponse.json({ families: { data: mockFamiliesData } })
+  }),
+  http.get('*/v1/family/:id/edit', ({ params }) => {
+    const { id } = params
+    if (id === 'mockCCLWFamilyWithOneEvent') {
+      return HttpResponse.json({ ...mockCCLWFamilyWithOneEvent })
+    }
+    return HttpResponse.json({ ...mockFamiliesData[0] })
+  }),
+
+  http.get('*/v1/collections/*', () => {
+    return HttpResponse.json([])
+  }),
+
+  http.get('*/v1/events/:id', () => {
+    return HttpResponse.json({ ...mockEvent })
+  }),
+  http.put('*/v1/events/:id', async ({ request, params }) => {
+    const { id } = params
+    const updateData = await request.json()
+    updateEvent(updateData as IEvent, id as string)
+    return HttpResponse.json({ ...mockEvent })
+  }),
 ]

--- a/src/tests/mocks/repository.ts
+++ b/src/tests/mocks/repository.ts
@@ -1,0 +1,23 @@
+import { IEvent } from '@/interfaces/Event'
+import { mockEvent } from '../utilsTest/mocks'
+
+let eventRepository = [mockEvent]
+
+const getEvent = (id: string) => {
+  return eventRepository.find((event) => event.import_id === id)
+}
+
+const updateEvent = (data: IEvent, id: string) => {
+  eventRepository = eventRepository.map((event) => {
+    if (id === event.import_id) {
+      return { ...event, ...data }
+    }
+    return event
+  })
+}
+
+const reset = () => {
+  eventRepository = [mockEvent]
+}
+
+export { eventRepository, getEvent, updateEvent, reset }

--- a/src/tests/setup.js
+++ b/src/tests/setup.js
@@ -1,18 +1,29 @@
 import { cleanup } from '@testing-library/react'
+import { reset } from './mocks/repository.ts'
 import { server } from './mocks/server.ts'
 import * as matchers from '@testing-library/jest-dom/matchers'
 
 expect.extend(matchers)
 
 // Establish API mocking before all tests.
-beforeAll(() => server.listen())
+beforeAll(() => {
+  server.listen()
+  localStorage.setItem(
+    'token',
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc19zdXBlcnVzZXIiOnRydWV9.d72FxLE8LDpEX5_9_pF0NR8k1W1PZe73Nrd2zi2WJJ0',
+  )
+})
 
 // Reset any request handlers that we may add during the tests,
 // so they don't affect other tests.
 afterEach(() => {
   server.resetHandlers()
   cleanup()
+  reset()
 })
 
 // Clean up after the tests are finished.
-afterAll(() => server.close())
+afterAll(() => {
+  server.close()
+  localStorage.clear()
+})

--- a/src/tests/setup.js
+++ b/src/tests/setup.js
@@ -2,16 +2,14 @@ import { cleanup } from '@testing-library/react'
 import { reset } from './mocks/repository.ts'
 import { server } from './mocks/server.ts'
 import * as matchers from '@testing-library/jest-dom/matchers'
+import sign from 'jwt-encode'
 
 expect.extend(matchers)
 
 // Establish API mocking before all tests.
 beforeAll(() => {
   server.listen()
-  localStorage.setItem(
-    'token',
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc19zdXBlcnVzZXIiOnRydWV9.d72FxLE8LDpEX5_9_pF0NR8k1W1PZe73Nrd2zi2WJJ0',
-  )
+  localStorage.setItem('token', sign({ is_superuser: true }, ''))
 })
 
 // Reset any request handlers that we may add during the tests,

--- a/src/tests/utilsTest/mocks.tsx
+++ b/src/tests/utilsTest/mocks.tsx
@@ -1,4 +1,4 @@
-import { IConfig } from '@/interfaces'
+import { IConfig, IEvent } from '@/interfaces'
 import { ICCLWFamily, IUNFCCCFamily } from '@/interfaces/Family'
 
 const mockConfig = {
@@ -23,7 +23,12 @@ const mockConfig = {
     { value: 'en', label: 'English' },
     { value: 'es', label: 'Spanish' },
   ],
-  corpora: [],
+  corpora: [
+    {
+      corpus_import_id: 'CCLW.corpus.i00000001.n0000',
+      corpus_type: 'Law and Policies',
+    },
+  ],
   document: {
     roles: ['Role One', 'Role Two'],
     types: ['Type One', 'Type Two'],
@@ -114,6 +119,25 @@ const mockCCLWFamilyNoEvents: ICCLWFamily = {
   events: [], // Without events
   created: '7/2/2021',
   last_modified: '8/2/2021',
+}
+
+const mockCCLWFamilyWithOneEvent: ICCLWFamily = {
+  ...mockCCLWFamilyNoDocuments,
+  import_id: 'CCLW.family.6.0',
+  title: 'CCLW Family Six',
+  summary: 'Summary for CCLW Family Six with one event',
+  events: ['event5'],
+  created: '7/2/2021',
+  last_modified: '8/2/2021',
+}
+
+const mockEvent: IEvent = {
+  import_id: 'event5',
+  event_title: 'Test event title',
+  date: '11/07/2024',
+  event_type_value: 'Event One',
+  event_status: 'Submitted',
+  family_import_id: 'CCLW.family.6.0',
 }
 
 const mockDocument = {
@@ -257,3 +281,5 @@ export { mockConfig as configMock }
 export { mockCCLWConfig as cclwConfigMock }
 export { mockUNFCCCConfig as unfcccConfigMock }
 export { mockDocument }
+export { mockEvent }
+export { mockCCLWFamilyWithOneEvent }

--- a/src/tests/utilsTest/renderRoute.tsx
+++ b/src/tests/utilsTest/renderRoute.tsx
@@ -1,0 +1,35 @@
+import AuthProvider from '@/providers/AuthProvider'
+import { familyRoutes } from '@/routes/familyRoutes'
+import { ChakraProvider } from '@chakra-ui/react'
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { RouterProvider, createBrowserRouter } from 'react-router-dom'
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+})
+
+export const renderRoute = (route = '/') => {
+  window.history.pushState({}, 'Test page', route)
+
+  return {
+    user: userEvent.setup(),
+    ...render(
+      <ChakraProvider>
+        <AuthProvider>
+          <RouterProvider router={createBrowserRouter(familyRoutes)} />
+        </AuthProvider>
+      </ChakraProvider>,
+    ),
+  }
+}

--- a/src/tests/views/Family.test.tsx
+++ b/src/tests/views/Family.test.tsx
@@ -1,0 +1,87 @@
+import userEvent from '@testing-library/user-event'
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from '@testing-library/react'
+import { RouterProvider, createBrowserRouter } from 'react-router-dom'
+import { familyRoutes } from '@/routes/familyRoutes'
+import { ChakraProvider } from '@chakra-ui/react'
+import AuthProvider from '@/providers/AuthProvider'
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual: unknown = await importOriginal()
+  return {
+    ...(actual as Record<string, unknown>),
+    useBlocker: vi.fn(),
+  }
+})
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+})
+
+const renderRoute = (route = '/') => {
+  window.history.pushState({}, 'Test page', route)
+
+  return {
+    user: userEvent.setup(),
+    ...render(
+      <ChakraProvider>
+        <AuthProvider>
+          <RouterProvider router={createBrowserRouter(familyRoutes)} />
+        </AuthProvider>
+      </ChakraProvider>,
+    ),
+  }
+}
+
+describe('FamilyForm edit', () => {
+  it('displays new event data after edit', async () => {
+    const { user } = renderRoute('/family/mockCCLWFamilyWithOneEvent/edit')
+
+    expect(
+      await screen.findByText('Editing: CCLW Family Six'),
+    ).toBeInTheDocument()
+    expect(await screen.findByText('Events')).toBeInTheDocument()
+    expect(await screen.findByText('Test event title')).toBeInTheDocument()
+
+    await user.click(screen.getByTestId('edit-event5'))
+
+    expect(
+      screen.getByRole('dialog', {
+        name: 'Edit: Test event title, on 11/7/2024',
+      }),
+    ).toBeInTheDocument()
+
+    const eventTitle = screen.getByRole('textbox', { name: 'Title' })
+
+    expect(eventTitle).toHaveValue('Test event title')
+
+    await user.type(eventTitle, 'New event title')
+
+    await user.click(screen.getByRole('button', { name: 'Update Event' }))
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByRole('dialog', {
+        name: 'Edit: Test event title, on 11/7/2024',
+      }),
+    )
+
+    expect(
+      await screen.findByText('Event has been successfully updated'),
+    ).toBeInTheDocument()
+    // expect(await screen.findByText('New event title')).toBeInTheDocument()
+    // expect(await screen.queryByText('Test event title')).not.toBeInTheDocument()
+  })
+})

--- a/src/tests/views/Family.test.tsx
+++ b/src/tests/views/Family.test.tsx
@@ -68,6 +68,8 @@ describe('FamilyForm edit', () => {
 
     expect(eventTitle).toHaveValue('Test event title')
 
+    await user.clear(eventTitle)
+
     await user.type(eventTitle, 'New event title')
 
     await user.click(screen.getByRole('button', { name: 'Update Event' }))
@@ -81,7 +83,7 @@ describe('FamilyForm edit', () => {
     expect(
       await screen.findByText('Event has been successfully updated'),
     ).toBeInTheDocument()
-    // expect(await screen.findByText('New event title')).toBeInTheDocument()
-    // expect(await screen.queryByText('Test event title')).not.toBeInTheDocument()
+    expect(await screen.findByText('New event title')).toBeInTheDocument()
+    expect(screen.queryByText('Test event title')).not.toBeInTheDocument()
   })
 })

--- a/src/tests/views/Family.test.tsx
+++ b/src/tests/views/Family.test.tsx
@@ -1,13 +1,5 @@
-import userEvent from '@testing-library/user-event'
-import {
-  render,
-  screen,
-  waitForElementToBeRemoved,
-} from '@testing-library/react'
-import { RouterProvider, createBrowserRouter } from 'react-router-dom'
-import { familyRoutes } from '@/routes/familyRoutes'
-import { ChakraProvider } from '@chakra-ui/react'
-import AuthProvider from '@/providers/AuthProvider'
+import { screen, waitForElementToBeRemoved } from '@testing-library/react'
+import { renderRoute } from '../utilsTest/renderRoute'
 
 vi.mock('react-router-dom', async (importOriginal) => {
   const actual: unknown = await importOriginal()
@@ -16,35 +8,6 @@ vi.mock('react-router-dom', async (importOriginal) => {
     useBlocker: vi.fn(),
   }
 })
-
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: vi.fn().mockImplementation((query: string) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: vi.fn(),
-    removeListener: vi.fn(),
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    dispatchEvent: vi.fn(),
-  })),
-})
-
-const renderRoute = (route = '/') => {
-  window.history.pushState({}, 'Test page', route)
-
-  return {
-    user: userEvent.setup(),
-    ...render(
-      <ChakraProvider>
-        <AuthProvider>
-          <RouterProvider router={createBrowserRouter(familyRoutes)} />
-        </AuthProvider>
-      </ChakraProvider>,
-    ),
-  }
-}
 
 describe('FamilyForm edit', () => {
   it('displays new event data after edit', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3956,6 +3956,13 @@ jwt-decode@*, jwt-decode@^4.0.0:
   resolved "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz"
   integrity sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==
 
+jwt-encode@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/jwt-encode/-/jwt-encode-1.0.1.tgz#6602a0475f757c7d5d559a7e923f3d3d5ecd938c"
+  integrity sha512-QrGiNhynbAYyFdbC1GbjborzenSFs5Ga+2nE0uBokGXsH11xrgd1AX55HR7P+wGQyyZOn6LUO5iKlh74dlhBkA==
+  dependencies:
+    ts.cryptojs256 "^1.0.1"
+
 keyv@^4.5.3:
   version "4.5.4"
   resolved "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz"
@@ -5229,6 +5236,11 @@ ts-node@^10.9.2:
     make-error "^1.1.1"
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
+
+ts.cryptojs256@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ts.cryptojs256/-/ts.cryptojs256-1.0.1.tgz#56a3d3a3bc022ad358b3e62cd8dae3224d9384f1"
+  integrity sha512-9XtEgRVOZBCdpPcCEhfvv9I2AVXdvfI81I/KpFM0wEfbq5JVHlXH7bfIjGQmYrIHGiBEHKsIaStQ87k926J7dA==
 
 tslib@2.4.0:
   version "2.4.0"


### PR DESCRIPTION
# What's changed
- added a fake API and repository for mocking calls in tests
- extracted family routes to a separate file so they can be tested
- added a render function for routes so we can test them easily
- added a test to reproduce the bug
- fixed the bug by reloading the UseEvent hook after edit

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
