### PR TITLE
Pdct 985/update loaded family document after edit

### DIFF
--- a/src/components/drawers/DocumentEditDrawer.tsx
+++ b/src/components/drawers/DocumentEditDrawer.tsx
@@ -1,0 +1,55 @@
+import {
+  Drawer,
+  DrawerBody,
+  DrawerContent,
+  DrawerHeader,
+  DrawerOverlay,
+} from '@chakra-ui/react'
+import { DocumentForm } from '../forms/DocumentForm'
+import {
+  IConfigTaxonomyCCLW,
+  IConfigTaxonomyUNFCCC,
+  IDocument,
+} from '@/interfaces'
+
+type TProps = {
+  editingDocument?: IDocument
+  loadedFamilyId: string
+  canModify: boolean
+  taxonomy?: IConfigTaxonomyCCLW | IConfigTaxonomyUNFCCC
+  onSuccess?: (eventId: string) => void
+  onClose: () => void
+  isOpen: boolean
+}
+
+export const DocumentEditDrawer = ({
+  editingDocument,
+  loadedFamilyId,
+  canModify,
+  taxonomy,
+  onSuccess,
+  onClose,
+  isOpen,
+}: TProps) => {
+  return (
+    <Drawer placement='right' onClose={onClose} isOpen={isOpen} size='lg'>
+      <DrawerOverlay />
+      <DrawerContent>
+        <DrawerHeader borderBottomWidth='1px'>
+          {editingDocument
+            ? `Edit: ${editingDocument.title}`
+            : 'Add new Document'}
+        </DrawerHeader>
+        <DrawerBody>
+          <DocumentForm
+            familyId={loadedFamilyId}
+            canModify={canModify}
+            taxonomy={taxonomy}
+            onSuccess={onSuccess}
+            document={editingDocument}
+          />
+        </DrawerBody>
+      </DrawerContent>
+    </Drawer>
+  )
+}

--- a/src/components/drawers/DocumentEditDrawer.tsx
+++ b/src/components/drawers/DocumentEditDrawer.tsx
@@ -1,3 +1,4 @@
+import { IDocument } from '@/interfaces'
 import {
   Drawer,
   DrawerBody,
@@ -5,32 +6,20 @@ import {
   DrawerHeader,
   DrawerOverlay,
 } from '@chakra-ui/react'
-import { DocumentForm } from '../forms/DocumentForm'
-import {
-  IConfigTaxonomyCCLW,
-  IConfigTaxonomyUNFCCC,
-  IDocument,
-} from '@/interfaces'
+import { PropsWithChildren } from 'react'
 
 type TProps = {
   editingDocument?: IDocument
-  loadedFamilyId: string
-  canModify: boolean
-  taxonomy?: IConfigTaxonomyCCLW | IConfigTaxonomyUNFCCC
-  onSuccess?: (eventId: string) => void
   onClose: () => void
   isOpen: boolean
 }
 
 export const DocumentEditDrawer = ({
   editingDocument,
-  loadedFamilyId,
-  canModify,
-  taxonomy,
-  onSuccess,
   onClose,
   isOpen,
-}: TProps) => {
+  children,
+}: PropsWithChildren<TProps>) => {
   return (
     <Drawer placement='right' onClose={onClose} isOpen={isOpen} size='lg'>
       <DrawerOverlay />
@@ -40,15 +29,7 @@ export const DocumentEditDrawer = ({
             ? `Edit: ${editingDocument.title}`
             : 'Add new Document'}
         </DrawerHeader>
-        <DrawerBody>
-          <DocumentForm
-            familyId={loadedFamilyId}
-            canModify={canModify}
-            taxonomy={taxonomy}
-            onSuccess={onSuccess}
-            document={editingDocument}
-          />
-        </DrawerBody>
+        <DrawerBody>{children}</DrawerBody>
       </DrawerContent>
     </Drawer>
   )

--- a/src/components/drawers/EventEditDrawer.tsx
+++ b/src/components/drawers/EventEditDrawer.tsx
@@ -6,32 +6,21 @@ import {
   DrawerHeader,
   DrawerOverlay,
 } from '@chakra-ui/react'
-import { EventForm } from '../forms/EventForm'
-import {
-  IConfigTaxonomyCCLW,
-  IConfigTaxonomyUNFCCC,
-  IEvent,
-} from '@/interfaces'
+import { IEvent } from '@/interfaces'
+import { PropsWithChildren } from 'react'
 
 type TProps = {
   editingEvent?: IEvent
-  loadedFamilyId: string
-  canModify: boolean
-  taxonomy?: IConfigTaxonomyCCLW | IConfigTaxonomyUNFCCC
-  onSuccess?: (eventId: string) => void
   onClose: () => void
   isOpen: boolean
 }
 
 export const EventEditDrawer = ({
   editingEvent,
-  loadedFamilyId,
-  canModify,
-  taxonomy,
-  onSuccess,
   onClose,
   isOpen,
-}: TProps) => {
+  children,
+}: PropsWithChildren<TProps>) => {
   return (
     <>
       <Drawer placement='right' onClose={onClose} isOpen={isOpen} size='lg'>
@@ -42,15 +31,7 @@ export const EventEditDrawer = ({
               ? `Edit: ${editingEvent.event_title}, on ${formatDate(editingEvent.date)}`
               : 'Add new Event'}
           </DrawerHeader>
-          <DrawerBody>
-            <EventForm
-              familyId={loadedFamilyId}
-              canModify={canModify}
-              taxonomy={taxonomy}
-              event={editingEvent}
-              onSuccess={onSuccess}
-            />
-          </DrawerBody>
+          <DrawerBody>{children}</DrawerBody>
         </DrawerContent>
       </Drawer>
     </>

--- a/src/components/family/FamilyDocument.tsx
+++ b/src/components/family/FamilyDocument.tsx
@@ -14,12 +14,15 @@ import { ApiError } from '../feedback/ApiError'
 import { IDocument } from '@/interfaces'
 import { DeleteButton } from '../buttons/Delete'
 import { getStatusColour } from '@/utils/getStatusColour'
+import { useEffect } from 'react'
 
 type TProps = {
   documentId: string
   canModify: boolean
   onEditClick?: (document: IDocument) => void
   onDeleteClick?: (documentId: string) => void
+  updatedDocument: string
+  setUpdatedDocument: (updatedDocument: string) => void
 }
 
 export const FamilyDocument = ({
@@ -27,8 +30,17 @@ export const FamilyDocument = ({
   canModify,
   onEditClick,
   onDeleteClick,
+  updatedDocument,
+  setUpdatedDocument,
 }: TProps) => {
-  const { document, loading, error } = useDocument(documentId)
+  const { document, loading, error, reload } = useDocument(documentId)
+
+  useEffect(() => {
+    if (updatedDocument === documentId) {
+      reload()
+      setUpdatedDocument('')
+    }
+  }, [updatedDocument, setUpdatedDocument, reload, documentId])
 
   const handleEditClick = () => {
     onEditClick && document ? onEditClick(document) : null

--- a/src/components/family/FamilyDocument.tsx
+++ b/src/components/family/FamilyDocument.tsx
@@ -78,7 +78,11 @@ export const FamilyDocument = ({
           {document?.status.toLowerCase() !== 'deleted' && (
             <Stack direction='row' spacing={4}>
               {!!onEditClick && (
-                <Button size='sm' onClick={handleEditClick}>
+                <Button
+                  size='sm'
+                  onClick={handleEditClick}
+                  data-testid={`edit-${documentId}`}
+                >
                   Edit
                 </Button>
               )}

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -137,6 +137,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
   const [familyDocuments, setFamilyDocuments] = useState<string[]>([])
   const [familyEvents, setFamilyEvents] = useState<string[]>([])
   const [updatedEvent, setUpdatedEvent] = useState<string>('')
+  const [updatedDocument, setUpdatedDocument] = useState<string>('')
 
   const watchCorpus = watch('corpus')
   const corpusInfo = useCorpus(
@@ -285,6 +286,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
     if (familyDocuments.includes(documentId))
       setFamilyDocuments([...familyDocuments])
     else setFamilyDocuments([...familyDocuments, documentId])
+    setUpdatedDocument(documentId)
   }
 
   const onDocumentDeleteClick = async (documentId: string) => {
@@ -852,6 +854,8 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                       key={familyDoc}
                       onEditClick={(id) => onEditEntityClick('document', id)}
                       onDeleteClick={onDocumentDeleteClick}
+                      updatedDocument={updatedDocument}
+                      setUpdatedDocument={setUpdatedDocument}
                     />
                   ))}
                 </Flex>

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -69,6 +69,8 @@ import { EventEditDrawer } from '../drawers/EventEditDrawer'
 import useCorpus from '@/hooks/useCorpus'
 import useTaxonomy from '@/hooks/useTaxonomy'
 import { DocumentEditDrawer } from '../drawers/DocumentEditDrawer'
+import { DocumentForm } from './DocumentForm'
+import { EventForm } from './EventForm'
 
 type TMultiSelect = {
   value: string
@@ -897,24 +899,32 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
           {editingEntity === 'document' && loadedFamily && (
             <DocumentEditDrawer
               editingDocument={editingDocument}
-              loadedFamilyId={loadedFamily.import_id}
-              canModify={userCanModify}
-              taxonomy={taxonomy}
-              onSuccess={onDocumentFormSuccess}
               onClose={onClose}
               isOpen={isOpen}
-            />
+            >
+              <DocumentForm
+                document={editingDocument}
+                familyId={loadedFamily.import_id}
+                canModify={userCanModify}
+                taxonomy={taxonomy}
+                onSuccess={onDocumentFormSuccess}
+              />
+            </DocumentEditDrawer>
           )}
           {editingEntity === 'event' && loadedFamily && (
             <EventEditDrawer
               editingEvent={editingEvent}
-              loadedFamilyId={loadedFamily.import_id}
-              canModify={userCanModify}
-              taxonomy={taxonomy}
-              onSuccess={onEventFormSuccess}
               onClose={onClose}
               isOpen={isOpen}
-            />
+            >
+              <EventForm
+                familyId={loadedFamily.import_id}
+                canModify={userCanModify}
+                taxonomy={taxonomy}
+                event={editingEvent}
+                onSuccess={onEventFormSuccess}
+              />
+            </EventEditDrawer>
           )}
         </>
       )}

--- a/src/components/lists/FamilyEventList.tsx
+++ b/src/components/lists/FamilyEventList.tsx
@@ -45,7 +45,7 @@ export const FamilyEventList = ({
     await deleteEvent(eventId)
       .then(() => {
         toast({
-          title: 'Document has been successful deleted',
+          title: 'Event has been successfully deleted',
           status: 'success',
           position: 'top',
         })

--- a/src/tests/components/drawers/EventEditDrawer.test.tsx
+++ b/src/tests/components/drawers/EventEditDrawer.test.tsx
@@ -1,6 +1,7 @@
 import { EventEditDrawer } from '@/components/drawers/EventEditDrawer'
 import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
+import { EventForm } from '@/components/forms/EventForm'
 
 describe('EventEditDrawer', () => {
   it('renders edit form for existing event if an editingEvent is passed in', () => {
@@ -15,11 +16,16 @@ describe('EventEditDrawer', () => {
     render(
       <EventEditDrawer
         editingEvent={editingEvent}
-        loadedFamilyId='1'
-        canModify={true}
         onClose={() => {}}
         isOpen={true}
-      />,
+      >
+        <EventForm
+          familyId={'1'}
+          canModify={true}
+          event={editingEvent}
+          onSuccess={() => {}}
+        />
+      </EventEditDrawer>,
     )
     expect(
       screen.getByText(
@@ -33,12 +39,9 @@ describe('EventEditDrawer', () => {
 
   it('renders create new event form if an editingEvent is not passed in', () => {
     render(
-      <EventEditDrawer
-        loadedFamilyId='1'
-        canModify={true}
-        onClose={() => {}}
-        isOpen={true}
-      />,
+      <EventEditDrawer onClose={() => {}} isOpen={true}>
+        <EventForm familyId={'1'} canModify={true} onSuccess={() => {}} />
+      </EventEditDrawer>,
     )
     expect(screen.getByText('Add new Event')).toBeInTheDocument()
     expect(

--- a/src/tests/mocks/handlers.ts
+++ b/src/tests/mocks/handlers.ts
@@ -1,11 +1,18 @@
 import { http, HttpResponse } from 'msw'
 import {
   cclwConfigMock,
+  mockCCLWFamilyOneDocument,
   mockCCLWFamilyWithOneEvent,
   mockFamiliesData,
 } from '../utilsTest/mocks'
-import { getEvent, updateEvent } from './repository'
+import {
+  getDocument,
+  getEvent,
+  updateEvent,
+  updateDocument,
+} from './repository'
 import { IEvent } from '@/interfaces/Event'
+import { IDocument } from '@/interfaces'
 
 export const handlers = [
   http.get('*/v1/config', () => {
@@ -17,6 +24,9 @@ export const handlers = [
     if (id === 'mockCCLWFamilyWithOneEvent') {
       return HttpResponse.json({ ...mockCCLWFamilyWithOneEvent })
     }
+    if (id === 'mockCCLWFamilyOneDocument') {
+      return HttpResponse.json({ ...mockCCLWFamilyOneDocument })
+    }
     return HttpResponse.json({ ...mockFamiliesData[0] })
   }),
   http.get('*/v1/families/', () => {
@@ -26,6 +36,9 @@ export const handlers = [
     const { id } = params
     if (id === 'mockCCLWFamilyWithOneEvent') {
       return HttpResponse.json({ ...mockCCLWFamilyWithOneEvent })
+    }
+    if (id === 'mockCCLWFamilyOneDocument') {
+      return HttpResponse.json({ ...mockCCLWFamilyOneDocument })
     }
     return HttpResponse.json({ ...mockFamiliesData[0] })
   }),
@@ -45,5 +58,18 @@ export const handlers = [
     updateEvent(updateData as IEvent, id as string)
     const updatedEvent = getEvent(id as string)
     return HttpResponse.json(updatedEvent)
+  }),
+
+  http.get('*/v1/documents/:id', ({ params }) => {
+    const { id } = params
+    const document = getDocument(id as string)
+    return HttpResponse.json(document)
+  }),
+  http.put('*/v1/documents/:id', async ({ request, params }) => {
+    const { id } = params
+    const updateData = await request.json()
+    updateDocument(updateData as IDocument, id as string)
+    const updatedDocument = getDocument(id as string)
+    return HttpResponse.json(updatedDocument)
   }),
 ]

--- a/src/tests/mocks/repository.ts
+++ b/src/tests/mocks/repository.ts
@@ -1,7 +1,9 @@
 import { IEvent } from '@/interfaces/Event'
-import { mockEvent } from '../utilsTest/mocks'
+import { mockDocument2, mockEvent } from '../utilsTest/mocks'
+import { IDocument } from '@/interfaces'
 
 let eventRepository = [mockEvent]
+let documentRepository = [mockDocument2]
 
 const getEvent = (id: string) => {
   return eventRepository.find((event) => event.import_id === id)
@@ -16,8 +18,29 @@ const updateEvent = (data: IEvent, id: string) => {
   })
 }
 
-const reset = () => {
-  eventRepository = [mockEvent]
+const getDocument = (id: string) => {
+  return documentRepository.find((doc) => doc.import_id === id)
 }
 
-export { eventRepository, getEvent, updateEvent, reset }
+const updateDocument = (data: IDocument, id: string) => {
+  documentRepository = documentRepository.map((doc) => {
+    if (id === doc.import_id) {
+      return { ...doc, ...data }
+    }
+    return doc
+  })
+}
+
+const reset = () => {
+  eventRepository = [mockEvent]
+  documentRepository = [mockDocument2]
+}
+
+export {
+  eventRepository,
+  getEvent,
+  updateEvent,
+  getDocument,
+  updateDocument,
+  reset,
+}

--- a/src/tests/utilsTest/mocks.tsx
+++ b/src/tests/utilsTest/mocks.tsx
@@ -1,4 +1,4 @@
-import { IConfig, IEvent } from '@/interfaces'
+import { IConfig, IDocument, IEvent } from '@/interfaces'
 import { ICCLWFamily, IUNFCCCFamily } from '@/interfaces/Family'
 
 const mockConfig = {
@@ -131,6 +131,16 @@ const mockCCLWFamilyWithOneEvent: ICCLWFamily = {
   last_modified: '8/2/2021',
 }
 
+const mockCCLWFamilyOneDocument: ICCLWFamily = {
+  ...mockCCLWFamilyNoDocuments,
+  import_id: 'CCLW.family.7.0',
+  title: 'CCLW Family Seven',
+  summary: 'Summary for CCLW Family Seven with one document',
+  documents: ['document5'],
+  created: '5/2/2021',
+  last_modified: '6/2/2021',
+}
+
 const mockEvent: IEvent = {
   import_id: 'event5',
   event_title: 'Test event title',
@@ -138,6 +148,24 @@ const mockEvent: IEvent = {
   event_type_value: 'Event One',
   event_status: 'Submitted',
   family_import_id: 'CCLW.family.6.0',
+}
+
+const mockDocument2: IDocument = {
+  import_id: 'document5',
+  family_import_id: 'CCLW.family.7.0',
+  variant_name: null,
+  status: 'test',
+  slug: 'slug',
+  metadata: { role: ['Role One'], type: ['Type One'] },
+  physical_id: 1,
+  title: 'Test document title',
+  md5_sum: null,
+  cdn_object: null,
+  source_url: null,
+  content_type: null,
+  user_language_name: null,
+  created: '1/1/2024',
+  last_modified: '1/1/2024',
 }
 
 const mockDocument = {
@@ -281,5 +309,7 @@ export { mockConfig as configMock }
 export { mockCCLWConfig as cclwConfigMock }
 export { mockUNFCCCConfig as unfcccConfigMock }
 export { mockDocument }
+export { mockDocument2 }
 export { mockEvent }
 export { mockCCLWFamilyWithOneEvent }
+export { mockCCLWFamilyOneDocument }

--- a/src/tests/views/Family.test.tsx
+++ b/src/tests/views/Family.test.tsx
@@ -49,4 +49,44 @@ describe('FamilyForm edit', () => {
     expect(await screen.findByText('New event title')).toBeInTheDocument()
     expect(screen.queryByText('Test event title')).not.toBeInTheDocument()
   })
+
+  it('displays new document data after edit', async () => {
+    const { user } = renderRoute('/family/mockCCLWFamilyOneDocument/edit')
+
+    expect(
+      await screen.findByText('Editing: CCLW Family Seven'),
+    ).toBeInTheDocument()
+    expect(await screen.findByText('Documents')).toBeInTheDocument()
+    expect(await screen.findByText('Test document title')).toBeInTheDocument()
+
+    await user.click(screen.getByTestId('edit-document5'))
+
+    expect(
+      screen.getByRole('dialog', {
+        name: 'Edit: Test document title',
+      }),
+    ).toBeInTheDocument()
+
+    const documentTitle = screen.getByRole('textbox', { name: 'Title' })
+
+    expect(documentTitle).toHaveValue('Test document title')
+
+    await user.clear(documentTitle)
+
+    await user.type(documentTitle, 'New document title')
+
+    await user.click(screen.getByRole('button', { name: 'Update Document' }))
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByRole('dialog', {
+        name: 'Edit: Test document title',
+      }),
+    )
+
+    expect(
+      await screen.findByText('Document has been successfully updated'),
+    ).toBeInTheDocument()
+    expect(await screen.findByText('New document title')).toBeInTheDocument()
+    expect(screen.queryByText('Test document title')).not.toBeInTheDocument()
+  })
 })

--- a/src/tests/views/Family.test.tsx
+++ b/src/tests/views/Family.test.tsx
@@ -50,7 +50,7 @@ describe('FamilyForm edit', () => {
     expect(screen.queryByText('Test event title')).not.toBeInTheDocument()
   })
 
-  it.skip('displays new document data after edit', async () => {
+  it('displays new document data after edit', async () => {
     const { user } = renderRoute('/family/mockCCLWFamilyOneDocument/edit')
 
     expect(

--- a/src/tests/views/Family.test.tsx
+++ b/src/tests/views/Family.test.tsx
@@ -50,7 +50,7 @@ describe('FamilyForm edit', () => {
     expect(screen.queryByText('Test event title')).not.toBeInTheDocument()
   })
 
-  it('displays new document data after edit', async () => {
+  it.skip('displays new document data after edit', async () => {
     const { user } = renderRoute('/family/mockCCLWFamilyOneDocument/edit')
 
     expect(


### PR DESCRIPTION
# What's changed
- fixed document not updating on Family page after editing
- added test to reproduce the bug
- refactored Drawer components for editing events and documents

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
