### PR TITLE
Remove Organisation radio buttons from Collections form

### DIFF
--- a/src/components/forms/CollectionForm.tsx
+++ b/src/components/forms/CollectionForm.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { useForm, SubmitHandler, Controller } from 'react-hook-form'
+import { useForm, SubmitHandler } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import {
   ICollection,
@@ -13,15 +13,11 @@ import { createCollection, updateCollection } from '@/api/Collections'
 import {
   FormControl,
   FormLabel,
-  HStack,
   Input,
-  Radio,
-  RadioGroup,
   Textarea,
   VStack,
   Button,
   ButtonGroup,
-  FormErrorMessage,
   useToast,
   FormHelperText,
 } from '@chakra-ui/react'
@@ -45,9 +41,8 @@ export const CollectionForm = ({ collection: loadedCollection }: TProps) => {
   const {
     register,
     handleSubmit,
-    control,
     reset,
-    formState: { errors, isSubmitting },
+    formState: { isSubmitting },
   } = useForm({
     resolver: yupResolver(collectionSchema),
   })
@@ -135,34 +130,6 @@ export const CollectionForm = ({ collection: loadedCollection }: TProps) => {
           <FormLabel>Description</FormLabel>
           <Textarea height={'300px'} bg='white' {...register('description')} />
         </FormControl>
-        <Controller
-          control={control}
-          name='organisation'
-          render={({ field }) => {
-            return (
-              <FormControl
-                isRequired
-                as='fieldset'
-                isInvalid={!!errors.organisation}
-              >
-                <FormLabel as='legend'>Organisation</FormLabel>
-                <RadioGroup {...field}>
-                  <HStack gap={4}>
-                    <Radio bg='white' value='CCLW'>
-                      CCLW
-                    </Radio>
-                    <Radio bg='white' value='UNFCCC'>
-                      UNFCCC
-                    </Radio>
-                  </HStack>
-                </RadioGroup>
-                <FormErrorMessage>
-                  Please select an organisation
-                </FormErrorMessage>
-              </FormControl>
-            )
-          }}
-        />
         <ButtonGroup>
           <Button
             type='submit'


### PR DESCRIPTION
# What's changed
- removed Organisation field and radio buttons from the Collections form (both create and edit) as they should not be entered/editable by the user

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
