### PR TITLE
Pdct 1221/remove vestige of organisation

### DIFF
--- a/src/components/forms/CollectionForm.tsx
+++ b/src/components/forms/CollectionForm.tsx
@@ -1,12 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useForm, SubmitHandler } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
-import {
-  ICollection,
-  ICollectionFormPost,
-  IError,
-  TOrganisation,
-} from '@/interfaces'
+import { ICollection, ICollectionFormPost, IError } from '@/interfaces'
 import { collectionSchema } from '@/schemas/collectionSchema'
 import { createCollection, updateCollection } from '@/api/Collections'
 
@@ -23,7 +18,6 @@ import {
 } from '@chakra-ui/react'
 import { useNavigate } from 'react-router-dom'
 import { ApiError } from '../feedback/ApiError'
-import useConfig from '@/hooks/useConfig'
 
 interface ICollectionForm {
   title: string
@@ -38,8 +32,6 @@ export const CollectionForm = ({ collection: loadedCollection }: TProps) => {
   const navigate = useNavigate()
   const toast = useToast()
   const [formError, setFormError] = useState<IError | null | undefined>()
-  const { config } = useConfig()
-  const organisation = config?.corpora[0].organisation
   const {
     register,
     handleSubmit,
@@ -55,13 +47,13 @@ export const CollectionForm = ({ collection: loadedCollection }: TProps) => {
     const collectionData: ICollectionFormPost = {
       title: collection.title,
       description: collection.description,
-      organisation: loadedCollection
-        ? loadedCollection.organisation
-        : (organisation?.name as TOrganisation),
     }
 
     if (loadedCollection) {
-      return await updateCollection(collectionData, loadedCollection.import_id)
+      return await updateCollection(
+        { ...collectionData, organisation: loadedCollection.organisation },
+        loadedCollection.import_id,
+      )
         .then(() => {
           toast.closeAll()
           toast({

--- a/src/components/forms/CollectionForm.tsx
+++ b/src/components/forms/CollectionForm.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { useForm, SubmitHandler, Controller } from 'react-hook-form'
+import { useForm, SubmitHandler } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import {
   ICollection,
@@ -13,15 +13,11 @@ import { createCollection, updateCollection } from '@/api/Collections'
 import {
   FormControl,
   FormLabel,
-  HStack,
   Input,
-  Radio,
-  RadioGroup,
   Textarea,
   VStack,
   Button,
   ButtonGroup,
-  FormErrorMessage,
   useToast,
   FormHelperText,
 } from '@chakra-ui/react'
@@ -45,9 +41,8 @@ export const CollectionForm = ({ collection: loadedCollection }: TProps) => {
   const {
     register,
     handleSubmit,
-    control,
     reset,
-    formState: { errors, isSubmitting },
+    formState: { isSubmitting },
   } = useForm({
     resolver: yupResolver(collectionSchema),
   })
@@ -135,34 +130,6 @@ export const CollectionForm = ({ collection: loadedCollection }: TProps) => {
           <FormLabel>Description</FormLabel>
           <Textarea height={'300px'} bg='white' {...register('description')} />
         </FormControl>
-        <Controller
-          control={control}
-          name='organisation'
-          render={({ field }) => {
-            return (
-              <FormControl
-                isRequired
-                as='fieldset'
-                isInvalid={!!errors.organisation}
-              >
-                <FormLabel as='legend'>Organisation</FormLabel>
-                <RadioGroup {...field}>
-                  <HStack gap={4}>
-                    <Radio bg='white' value='CCLW'>
-                      CCLW
-                    </Radio>
-                    <Radio bg='white' value='UNFCCC'>
-                      UNFCCC
-                    </Radio>
-                  </HStack>
-                </RadioGroup>
-                <FormErrorMessage>
-                  Please select an organisation
-                </FormErrorMessage>
-              </FormControl>
-            )
-          }}
-        />
         <ButtonGroup>
           <Button
             type='submit'

--- a/src/components/forms/CollectionForm.tsx
+++ b/src/components/forms/CollectionForm.tsx
@@ -23,11 +23,11 @@ import {
 } from '@chakra-ui/react'
 import { useNavigate } from 'react-router-dom'
 import { ApiError } from '../feedback/ApiError'
+import useConfig from '@/hooks/useConfig'
 
 interface ICollectionForm {
   title: string
   description?: string
-  organisation: string
 }
 
 type TProps = {
@@ -38,6 +38,8 @@ export const CollectionForm = ({ collection: loadedCollection }: TProps) => {
   const navigate = useNavigate()
   const toast = useToast()
   const [formError, setFormError] = useState<IError | null | undefined>()
+  const { config } = useConfig()
+  const organisation = config?.corpora[0].organisation
   const {
     register,
     handleSubmit,
@@ -53,7 +55,9 @@ export const CollectionForm = ({ collection: loadedCollection }: TProps) => {
     const collectionData: ICollectionFormPost = {
       title: collection.title,
       description: collection.description,
-      organisation: collection.organisation as TOrganisation,
+      organisation: loadedCollection
+        ? loadedCollection.organisation
+        : (organisation?.name as TOrganisation),
     }
 
     if (loadedCollection) {
@@ -106,7 +110,6 @@ export const CollectionForm = ({ collection: loadedCollection }: TProps) => {
       reset({
         title: loadedCollection.title,
         description: loadedCollection.description,
-        organisation: loadedCollection.organisation,
       })
     }
   }, [loadedCollection, reset])

--- a/src/interfaces/Collection.ts
+++ b/src/interfaces/Collection.ts
@@ -11,5 +11,5 @@ export interface ICollection {
 export interface ICollectionFormPost {
   title: string
   description?: string
-  organisation: TOrganisation
+  organisation?: TOrganisation
 }

--- a/src/routes/collectionRoutes.tsx
+++ b/src/routes/collectionRoutes.tsx
@@ -1,0 +1,29 @@
+import CollectionList from '@/components/lists/CollectionList'
+import Collection from '@/views/collection/Collection'
+import Collections from '@/views/collection/Collections'
+import ErrorPage from '@/views/Error'
+
+export const collectionRoutes = [
+  {
+    path: '/collection/new',
+    element: <Collection />,
+    errorElement: <ErrorPage />,
+  },
+  {
+    path: 'collection/:importId/edit',
+    element: <Collection />,
+    errorElement: <ErrorPage />,
+  },
+  {
+    path: 'collections',
+    element: <Collections />,
+    errorElement: <ErrorPage />,
+    children: [
+      {
+        path: '',
+        element: <CollectionList />,
+        errorElement: <ErrorPage />,
+      },
+    ],
+  },
+]

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -7,13 +7,11 @@ import Root from '@/Root'
 import Login from '@/views/auth/Login'
 import Dashboard from '@/views/dashboard/Dashboard'
 import ErrorPage from '@views/Error'
-import Collections from '@/views/collection/Collections'
-import CollectionList from '@/components/lists/CollectionList'
-import Collection from '@/views/collection/Collection'
 import Documents from '@/views/document/Documents'
 import DocumentList from '@/components/lists/DocumentList'
 import Document from '@/views/document/Document'
 import { familyRoutes } from './familyRoutes'
+import { collectionRoutes } from './collectionRoutes'
 
 const authenticatedRoutes = [
   {
@@ -34,28 +32,7 @@ const authenticatedRoutes = [
                 errorElement: <ErrorPage />,
               },
               ...familyRoutes,
-              {
-                path: '/collection/new',
-                element: <Collection />,
-                errorElement: <ErrorPage />,
-              },
-              {
-                path: 'collection/:importId/edit',
-                element: <Collection />,
-                errorElement: <ErrorPage />,
-              },
-              {
-                path: 'collections',
-                element: <Collections />,
-                errorElement: <ErrorPage />,
-                children: [
-                  {
-                    path: '',
-                    element: <CollectionList />,
-                    errorElement: <ErrorPage />,
-                  },
-                ],
-              },
+              ...collectionRoutes,
               {
                 path: 'document/:importId/edit',
                 element: <Document />,

--- a/src/schemas/collectionSchema.ts
+++ b/src/schemas/collectionSchema.ts
@@ -4,6 +4,5 @@ export const collectionSchema = yup
   .object({
     title: yup.string().required(),
     description: yup.string().optional(),
-    organisation: yup.string().required(),
   })
   .required()

--- a/src/tests/mocks/api/collectionHandlers.ts
+++ b/src/tests/mocks/api/collectionHandlers.ts
@@ -1,21 +1,32 @@
-import { mockCollection } from '@/tests/utilsTest/mocks'
+import {
+  getCollection,
+  createCollection,
+  updateCollection,
+} from '../repository'
+import { ICollection, ICollectionFormPost } from '@/interfaces'
 import { http, HttpResponse } from 'msw'
 
 export const collectionHandlers = [
-  http.get('*/v1/collection/:id/edit', () => {
-    return HttpResponse.json(mockCollection)
+  http.get('*/v1/collection/:id/edit', async ({ request, params }) => {
+    const { id } = params
+    const updateData = await request.json()
+    updateCollection(updateData as ICollection, id as string)
+    const updatedCollection = getCollection(id as string)
+    return HttpResponse.json(updatedCollection)
   }),
   http.get('*/v1/collections/:id', ({ params }) => {
     const { id } = params
-    if (id === mockCollection.id) {
-      return HttpResponse.json(mockCollection)
-    }
-    return HttpResponse.json([])
+    const collection = getCollection(id as string)
+    return HttpResponse.json(collection)
   }),
   http.get('*/v1/collections/*', () => {
     return HttpResponse.json([])
   }),
-  http.post('*/v1/collections', () => {
-    return HttpResponse.json(mockCollection.id)
+  http.post('*/v1/collections', async ({ request }) => {
+    const updateData = await request.json()
+    const createdCollectionId = createCollection(
+      updateData as ICollectionFormPost,
+    )
+    return HttpResponse.json(createdCollectionId)
   }),
 ]

--- a/src/tests/mocks/api/collectionHandlers.ts
+++ b/src/tests/mocks/api/collectionHandlers.ts
@@ -1,0 +1,21 @@
+import { mockCollection } from '@/tests/utilsTest/mocks'
+import { http, HttpResponse } from 'msw'
+
+export const collectionHandlers = [
+  http.get('*/v1/collection/:id/edit', () => {
+    return HttpResponse.json(mockCollection)
+  }),
+  http.get('*/v1/collections/:id', ({ params }) => {
+    const { id } = params
+    if (id === mockCollection.id) {
+      return HttpResponse.json(mockCollection)
+    }
+    return HttpResponse.json([])
+  }),
+  http.get('*/v1/collections/*', () => {
+    return HttpResponse.json([])
+  }),
+  http.post('*/v1/collections', () => {
+    return HttpResponse.json(mockCollection.id)
+  }),
+]

--- a/src/tests/mocks/api/documentHandlers.ts
+++ b/src/tests/mocks/api/documentHandlers.ts
@@ -1,0 +1,18 @@
+import { IDocument } from '@/interfaces'
+import { http, HttpResponse } from 'msw'
+import { getDocument, updateDocument } from '../repository'
+
+export const documentHandlers = [
+  http.get('*/v1/documents/:id', ({ params }) => {
+    const { id } = params
+    const document = getDocument(id as string)
+    return HttpResponse.json(document)
+  }),
+  http.put('*/v1/documents/:id', async ({ request, params }) => {
+    const { id } = params
+    const updateData = await request.json()
+    updateDocument(updateData as IDocument, id as string)
+    const updatedDocument = getDocument(id as string)
+    return HttpResponse.json(updatedDocument)
+  }),
+]

--- a/src/tests/mocks/api/eventHandlers.ts
+++ b/src/tests/mocks/api/eventHandlers.ts
@@ -1,0 +1,18 @@
+import { http, HttpResponse } from 'msw'
+import { getEvent, updateEvent } from '../repository'
+import { IEvent } from '@/interfaces/Event'
+
+export const eventHandlers = [
+  http.get('*/v1/events/:id', ({ params }) => {
+    const { id } = params
+    const event = getEvent(id as string)
+    return HttpResponse.json(event)
+  }),
+  http.put('*/v1/events/:id', async ({ request, params }) => {
+    const { id } = params
+    const updateData = await request.json()
+    updateEvent(updateData as IEvent, id as string)
+    const updatedEvent = getEvent(id as string)
+    return HttpResponse.json(updatedEvent)
+  }),
+]

--- a/src/tests/mocks/api/familyHandlers.ts
+++ b/src/tests/mocks/api/familyHandlers.ts
@@ -1,0 +1,32 @@
+import {
+  mockCCLWFamilyOneDocument,
+  mockCCLWFamilyWithOneEvent,
+  mockFamiliesData,
+} from '@/tests/utilsTest/mocks'
+import { http, HttpResponse } from 'msw'
+
+export const familyHandlers = [
+  http.get('*/v1/families/:id', ({ params }) => {
+    const { id } = params
+    if (id === 'mockCCLWFamilyWithOneEvent') {
+      return HttpResponse.json({ ...mockCCLWFamilyWithOneEvent })
+    }
+    if (id === 'mockCCLWFamilyOneDocument') {
+      return HttpResponse.json({ ...mockCCLWFamilyOneDocument })
+    }
+    return HttpResponse.json({ ...mockFamiliesData[0] })
+  }),
+  http.get('*/v1/families/', () => {
+    return HttpResponse.json({ families: { data: mockFamiliesData } })
+  }),
+  http.get('*/v1/family/:id/edit', ({ params }) => {
+    const { id } = params
+    if (id === 'mockCCLWFamilyWithOneEvent') {
+      return HttpResponse.json({ ...mockCCLWFamilyWithOneEvent })
+    }
+    if (id === 'mockCCLWFamilyOneDocument') {
+      return HttpResponse.json({ ...mockCCLWFamilyOneDocument })
+    }
+    return HttpResponse.json({ ...mockFamiliesData[0] })
+  }),
+]

--- a/src/tests/mocks/handlers.ts
+++ b/src/tests/mocks/handlers.ts
@@ -43,6 +43,9 @@ export const handlers = [
     return HttpResponse.json({ ...mockFamiliesData[0] })
   }),
 
+  http.get('*/v1/collection/new', () => {
+    return HttpResponse.json([])
+  }),
   http.get('*/v1/collections/*', () => {
     return HttpResponse.json([])
   }),

--- a/src/tests/mocks/handlers.ts
+++ b/src/tests/mocks/handlers.ts
@@ -3,6 +3,7 @@ import {
   cclwConfigMock,
   mockCCLWFamilyOneDocument,
   mockCCLWFamilyWithOneEvent,
+  mockCollection,
   mockFamiliesData,
 } from '../utilsTest/mocks'
 import {
@@ -43,11 +44,21 @@ export const handlers = [
     return HttpResponse.json({ ...mockFamiliesData[0] })
   }),
 
-  http.get('*/v1/collection/new', () => {
+  http.get('*/v1/collection/:id/edit', () => {
+    return HttpResponse.json(mockCollection)
+  }),
+  http.get('*/v1/collections/:id', ({ params }) => {
+    const { id } = params
+    if (id === mockCollection.id) {
+      return HttpResponse.json(mockCollection)
+    }
     return HttpResponse.json([])
   }),
   http.get('*/v1/collections/*', () => {
     return HttpResponse.json([])
+  }),
+  http.post('*/v1/collections', () => {
+    return HttpResponse.json(mockCollection.id)
   }),
 
   http.get('*/v1/events/:id', ({ params }) => {

--- a/src/tests/mocks/handlers.ts
+++ b/src/tests/mocks/handlers.ts
@@ -1,89 +1,16 @@
 import { http, HttpResponse } from 'msw'
-import {
-  cclwConfigMock,
-  mockCCLWFamilyOneDocument,
-  mockCCLWFamilyWithOneEvent,
-  mockCollection,
-  mockFamiliesData,
-} from '../utilsTest/mocks'
-import {
-  getDocument,
-  getEvent,
-  updateEvent,
-  updateDocument,
-} from './repository'
-import { IEvent } from '@/interfaces/Event'
-import { IDocument } from '@/interfaces'
+import { cclwConfigMock } from '../utilsTest/mocks'
+import { familyHandlers } from './api/familyHandlers'
+import { collectionHandlers } from './api/collectionHandlers'
+import { eventHandlers } from './api/eventHandlers'
+import { documentHandlers } from './api/documentHandlers'
 
 export const handlers = [
   http.get('*/v1/config', () => {
     return HttpResponse.json({ ...cclwConfigMock })
   }),
-
-  http.get('*/v1/families/:id', ({ params }) => {
-    const { id } = params
-    if (id === 'mockCCLWFamilyWithOneEvent') {
-      return HttpResponse.json({ ...mockCCLWFamilyWithOneEvent })
-    }
-    if (id === 'mockCCLWFamilyOneDocument') {
-      return HttpResponse.json({ ...mockCCLWFamilyOneDocument })
-    }
-    return HttpResponse.json({ ...mockFamiliesData[0] })
-  }),
-  http.get('*/v1/families/', () => {
-    return HttpResponse.json({ families: { data: mockFamiliesData } })
-  }),
-  http.get('*/v1/family/:id/edit', ({ params }) => {
-    const { id } = params
-    if (id === 'mockCCLWFamilyWithOneEvent') {
-      return HttpResponse.json({ ...mockCCLWFamilyWithOneEvent })
-    }
-    if (id === 'mockCCLWFamilyOneDocument') {
-      return HttpResponse.json({ ...mockCCLWFamilyOneDocument })
-    }
-    return HttpResponse.json({ ...mockFamiliesData[0] })
-  }),
-
-  http.get('*/v1/collection/:id/edit', () => {
-    return HttpResponse.json(mockCollection)
-  }),
-  http.get('*/v1/collections/:id', ({ params }) => {
-    const { id } = params
-    if (id === mockCollection.id) {
-      return HttpResponse.json(mockCollection)
-    }
-    return HttpResponse.json([])
-  }),
-  http.get('*/v1/collections/*', () => {
-    return HttpResponse.json([])
-  }),
-  http.post('*/v1/collections', () => {
-    return HttpResponse.json(mockCollection.id)
-  }),
-
-  http.get('*/v1/events/:id', ({ params }) => {
-    const { id } = params
-    const event = getEvent(id as string)
-    return HttpResponse.json(event)
-  }),
-  http.put('*/v1/events/:id', async ({ request, params }) => {
-    const { id } = params
-    const updateData = await request.json()
-    updateEvent(updateData as IEvent, id as string)
-    const updatedEvent = getEvent(id as string)
-    return HttpResponse.json(updatedEvent)
-  }),
-
-  http.get('*/v1/documents/:id', ({ params }) => {
-    const { id } = params
-    const document = getDocument(id as string)
-    return HttpResponse.json(document)
-  }),
-  http.put('*/v1/documents/:id', async ({ request, params }) => {
-    const { id } = params
-    const updateData = await request.json()
-    updateDocument(updateData as IDocument, id as string)
-    const updatedDocument = getDocument(id as string)
-    return HttpResponse.json(updatedDocument)
-  }),
+  ...familyHandlers,
+  ...collectionHandlers,
+  ...eventHandlers,
+  ...documentHandlers,
 ]

--- a/src/tests/mocks/repository.ts
+++ b/src/tests/mocks/repository.ts
@@ -1,9 +1,10 @@
 import { IEvent } from '@/interfaces/Event'
-import { mockDocument2, mockEvent } from '../utilsTest/mocks'
-import { IDocument } from '@/interfaces'
+import { mockCollection, mockDocument2, mockEvent } from '../utilsTest/mocks'
+import { ICollection, ICollectionFormPost, IDocument } from '@/interfaces'
 
 let eventRepository = [mockEvent]
 let documentRepository = [mockDocument2]
+let collectionRepository = [mockCollection]
 
 const getEvent = (id: string) => {
   return eventRepository.find((event) => event.import_id === id)
@@ -31,16 +32,44 @@ const updateDocument = (data: IDocument, id: string) => {
   })
 }
 
+const getCollection = (id: string) => {
+  return collectionRepository.find((coll) => coll.import_id === id)
+}
+
+const createCollection = (data: ICollectionFormPost) => {
+  const import_id = `${data.title}-${collectionRepository.length}`
+  collectionRepository.push({
+    title: data.title,
+    description: data.description ?? '',
+    import_id: import_id,
+    families: [],
+    organisation: 'CCLW',
+  })
+  return import_id
+}
+
+const updateCollection = (data: ICollection, id: string) => {
+  collectionRepository = collectionRepository.map((coll) => {
+    if (id === coll.import_id) {
+      return { ...coll, ...data }
+    }
+    return coll
+  })
+}
+
 const reset = () => {
   eventRepository = [mockEvent]
   documentRepository = [mockDocument2]
+  collectionRepository = [mockCollection]
 }
 
 export {
-  eventRepository,
   getEvent,
   updateEvent,
   getDocument,
   updateDocument,
+  getCollection,
+  createCollection,
+  updateCollection,
   reset,
 }

--- a/src/tests/utilsTest/mocks.tsx
+++ b/src/tests/utilsTest/mocks.tsx
@@ -1,4 +1,4 @@
-import { IConfig, IDocument, IEvent } from '@/interfaces'
+import { ICollection, IConfig, IDocument, IEvent } from '@/interfaces'
 import { ICCLWFamily, IUNFCCCFamily } from '@/interfaces/Family'
 
 const mockConfig = {
@@ -185,7 +185,13 @@ const mockDocument = {
   user_language_name: 'lang',
 }
 
-const mockCollection = { id: 'collection1', title: 'Test collection' }
+const mockCollection: ICollection = {
+  import_id: 'collection1',
+  title: 'Test collection',
+  description: 'Test description',
+  families: [],
+  organisation: 'UNFCCC',
+}
 
 const mockCCLWConfig: IConfig = {
   ...mockConfig,

--- a/src/tests/utilsTest/mocks.tsx
+++ b/src/tests/utilsTest/mocks.tsx
@@ -185,6 +185,8 @@ const mockDocument = {
   user_language_name: 'lang',
 }
 
+const mockCollection = { id: 'collection1', title: 'Test collection' }
+
 const mockCCLWConfig: IConfig = {
   ...mockConfig,
   corpora: [
@@ -313,3 +315,4 @@ export { mockDocument2 }
 export { mockEvent }
 export { mockCCLWFamilyWithOneEvent }
 export { mockCCLWFamilyOneDocument }
+export { mockCollection }

--- a/src/tests/utilsTest/renderRoute.tsx
+++ b/src/tests/utilsTest/renderRoute.tsx
@@ -1,4 +1,5 @@
 import AuthProvider from '@/providers/AuthProvider'
+import { collectionRoutes } from '@/routes/collectionRoutes'
 import { familyRoutes } from '@/routes/familyRoutes'
 import { ChakraProvider } from '@chakra-ui/react'
 import { render } from '@testing-library/react'
@@ -27,7 +28,9 @@ export const renderRoute = (route = '/') => {
     ...render(
       <ChakraProvider>
         <AuthProvider>
-          <RouterProvider router={createBrowserRouter(familyRoutes)} />
+          <RouterProvider
+            router={createBrowserRouter([...familyRoutes, ...collectionRoutes])}
+          />
         </AuthProvider>
       </ChakraProvider>,
     ),

--- a/src/tests/views/Collections.test.tsx
+++ b/src/tests/views/Collections.test.tsx
@@ -13,7 +13,7 @@ describe('Collection form', () => {
       }),
     ).toBeInTheDocument()
 
-    const newTitle = 'Test collection'
+    const newTitle = 'New collection title'
     await user.type(screen.getByRole('textbox', { name: 'Title' }), newTitle)
     await user.type(
       screen.getByRole('textbox', { name: 'Description' }),

--- a/src/tests/views/Collections.test.tsx
+++ b/src/tests/views/Collections.test.tsx
@@ -7,13 +7,14 @@ describe('Collection form', () => {
     const { user } = renderRoute('/collection/new')
 
     expect(
-      screen.getByRole('heading', { level: 1, name: 'Create new collection' }),
+      screen.getByRole('heading', {
+        level: 1,
+        name: 'Create new collection',
+      }),
     ).toBeInTheDocument()
 
-    await user.type(
-      screen.getByRole('textbox', { name: 'Title' }),
-      'Test collection',
-    )
+    const newTitle = 'Test collection'
+    await user.type(screen.getByRole('textbox', { name: 'Title' }), newTitle)
     await user.type(
       screen.getByRole('textbox', { name: 'Description' }),
       'Test description',
@@ -24,6 +25,12 @@ describe('Collection form', () => {
 
     expect(
       await screen.findByText('Collection has been successfully created'),
+    ).toBeInTheDocument()
+    expect(
+      await screen.findByRole('heading', {
+        level: 1,
+        name: `Editing: ${newTitle}`,
+      }),
     ).toBeInTheDocument()
   })
 })

--- a/src/tests/views/Collections.test.tsx
+++ b/src/tests/views/Collections.test.tsx
@@ -1,0 +1,29 @@
+import { screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { renderRoute } from '../utilsTest/renderRoute'
+
+describe('Collection form', () => {
+  it('successfully creates collection', async () => {
+    const { user } = renderRoute('/collection/new')
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Create new collection' }),
+    ).toBeInTheDocument()
+
+    await user.type(
+      screen.getByRole('textbox', { name: 'Title' }),
+      'Test collection',
+    )
+    await user.type(
+      screen.getByRole('textbox', { name: 'Description' }),
+      'Test description',
+    )
+    await user.click(
+      screen.getByRole('button', { name: 'Create new Collection' }),
+    )
+
+    expect(
+      await screen.findByText('Collection has been successfully created'),
+    ).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
# What's changed
- removed organisation radio buttons from the Collection form (both create and edit) as the value should be taken from the user context
- do not send the organisation field when creating a collection as it is not used in the backend
- added a test to cover creating of a new collection

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
