### PR TITLE
PDCT 1456 : validation of wysiwyg summary field

### DIFF
--- a/src/utils/stripHtml.ts
+++ b/src/utils/stripHtml.ts
@@ -1,0 +1,3 @@
+export const stripHtml = (html: string) => {
+  return html.replace(/<[^>]*>?/gm, '').trim()
+}

--- a/src/utils/stripHtml.ts
+++ b/src/utils/stripHtml.ts
@@ -1,3 +1,6 @@
 export const stripHtml = (html: string) => {
-  return html.replace(/<[^>]*>?/gm, '').trim()
+  return html
+    .replace(/<[^>]*>?/gm, '')
+    .replace(/&[^;]+;/g, '')
+    .trim()
 }


### PR DESCRIPTION
# What's changed
- Adding validation on the WYSIWYG field, this involves stripping out the HTML tags in order to check if the field is empty.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
