### PR TITLE
Feature/pdct 1717 bug document type values not in alphabetical order in

### DIFF
--- a/src/components/forms/DocumentForm.tsx
+++ b/src/components/forms/DocumentForm.tsx
@@ -231,11 +231,13 @@ export const DocumentForm = ({
                   <FormLabel as='legend'>Type</FormLabel>
                   <Select background='white' {...field}>
                     <option value=''>Please select</option>
-                    {taxonomy?._document?.type?.allowed_values.map((option) => (
-                      <option key={option} value={option}>
-                        {option}
-                      </option>
-                    ))}
+                    {taxonomy?._document?.type?.allowed_values
+                      .sort()
+                      .map((option) => (
+                        <option key={option} value={option}>
+                          {option}
+                        </option>
+                      ))}
                   </Select>
                   <FormErrorMessage>Please select a type</FormErrorMessage>
                 </FormControl>

--- a/src/tests/components/forms/DocumentForm.test.tsx
+++ b/src/tests/components/forms/DocumentForm.test.tsx
@@ -87,7 +87,7 @@ describe('DocumentForm', () => {
     expect(screen.getByText('Role One')).toBeInTheDocument()
   })
 
-  it('shows allowed values in alphabetical order when clicking on type dropdown', () => {
+  it('shows allowed values in alphabetical order in document type dropdown', () => {
     const taxonomyWithUnorderedDocTypes = {
       ...mockTaxonomy,
       _document: {

--- a/src/tests/components/forms/DocumentForm.test.tsx
+++ b/src/tests/components/forms/DocumentForm.test.tsx
@@ -87,6 +87,39 @@ describe('DocumentForm', () => {
     expect(screen.getByText('Role One')).toBeInTheDocument()
   })
 
+  it('shows allowed values in alphabetical order when clicking on type dropdown', () => {
+    const taxonomyWithUnorderedDocTypes = {
+      ...mockTaxonomy,
+      _document: {
+        role: {
+          allow_any: false,
+          allow_blanks: false,
+          allowed_values: ['Role One', 'Role Two'],
+        },
+        type: {
+          allow_any: false,
+          allow_blanks: false,
+          allowed_values: ['C', 'A', 'B'],
+        },
+      },
+    }
+
+    customRender(
+      <DocumentForm
+        familyId={'test'}
+        onSuccess={onDocumentFormSuccess}
+        document={mockDocument}
+        taxonomy={taxonomyWithUnorderedDocTypes}
+      />,
+    )
+
+    const allowedValues = within(screen.getByRole('group', { name: 'Type' }))
+      .getAllByRole('option')
+      .map((option) => option.textContent)
+
+    expect(allowedValues).toEqual(['Please select', 'A', 'B', 'C'])
+  })
+
   it('validate incorrect document URL', async () => {
     customRender(
       <DocumentForm


### PR DESCRIPTION
# What's changed

- sort taxonomy values for document type in create document form so they are in alphabetical order

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
