### PR TITLE
Move status filtering to table header

### DIFF
--- a/src/views/family/Families.tsx
+++ b/src/views/family/Families.tsx
@@ -27,12 +27,6 @@ import useConfig from '@/hooks/useConfig'
 import { getCountries } from '@/utils/extractNestedGeographyData'
 import { chakraStylesSelect } from '@/styles/chakra'
 
-const STATUSES = [
-  { value: 'Created', label: 'Created' },
-  { value: 'Published', label: 'Published' },
-  { value: 'Deleted', label: 'Deleted' },
-]
-
 export default function Families() {
   const navigation = useNavigation()
   const { config, error: configError, loading: configLoading } = useConfig()
@@ -50,15 +44,6 @@ export default function Families() {
       geography: selectedItem?.value ?? '',
       q: searchParams.get('q') ?? '',
       status: qStatus ?? '',
-    })
-  }
-
-  const handleChangeStatus = (newValue: unknown) => {
-    const selectedItem = newValue as { value: string; label: string }
-    setSearchParams({
-      geography: qGeography ?? '',
-      q: searchParams.get('q') ?? '',
-      status: selectedItem?.value ?? '',
     })
   }
 
@@ -136,18 +121,6 @@ export default function Families() {
                   />
                 </>
               )}
-            </Box>
-            <Box minW={200}>
-              <Text>Status</Text>
-              <CRSelect
-                chakraStyles={chakraStylesSelect}
-                isClearable={true}
-                isMulti={false}
-                isSearchable={true}
-                options={STATUSES}
-                onChange={handleChangeStatus}
-                defaultValue={qStatus && { value: qStatus, label: qStatus }}
-              />
             </Box>
           </Flex>
         </Form>


### PR DESCRIPTION
# What's changed

Move the status filtering in the admin service family list page to the status table heading.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
