### PR TITLE
Fix cannot edit mcf docs on admin frontend

### DIFF
--- a/src/components/forms/DocumentForm.tsx
+++ b/src/components/forms/DocumentForm.tsx
@@ -13,6 +13,7 @@ import {
   IError,
   IConfigTaxonomyCCLW,
   IConfigTaxonomyUNFCCC,
+  IConfigTaxonomyMCF,
 } from '@/interfaces'
 import { createDocument, updateDocument } from '@/api/Documents'
 import { documentSchema } from '@/schemas/documentSchema'
@@ -41,7 +42,7 @@ type TProps = {
   document?: IDocument
   familyId?: string
   canModify?: boolean
-  taxonomy?: IConfigTaxonomyCCLW | IConfigTaxonomyUNFCCC
+  taxonomy?: IConfigTaxonomyCCLW | IConfigTaxonomyUNFCCC | IConfigTaxonomyMCF
   onSuccess?: (documentId: string) => void
 }
 
@@ -147,8 +148,8 @@ export const DocumentForm = ({
       reset({
         family_import_id: loadedDocument.family_import_id,
         variant_name: loadedDocument.variant_name ?? '',
-        role: loadedDocument?.metadata?.role[0] ?? '',
-        type: loadedDocument?.metadata?.type[0] ?? '',
+        role: loadedDocument?.metadata?.role?.[0] ?? '',
+        type: loadedDocument?.metadata?.type?.[0] ?? '',
         title: loadedDocument.title,
         source_url: loadedDocument.source_url ?? '',
         user_language_name: loadedDocument.user_language_name
@@ -164,6 +165,8 @@ export const DocumentForm = ({
       })
     }
   }, [loadedDocument, familyId, reset])
+
+  console.log(taxonomy)
 
   return (
     <>
@@ -202,46 +205,62 @@ export const DocumentForm = ({
               {errors.source_url && errors.source_url.message}
             </FormErrorMessage>
           </FormControl>
-          <Controller
-            control={control}
-            name='role'
-            render={({ field }) => {
-              return (
-                <FormControl isRequired as='fieldset' isInvalid={!!errors.role}>
-                  <FormLabel as='legend'>Role</FormLabel>
-                  <Select background='white' {...field}>
-                    <option value=''>Please select</option>
-                    {taxonomy?._document?.role?.allowed_values.map((option) => (
-                      <option key={option} value={option}>
-                        {option}
-                      </option>
-                    ))}
-                  </Select>
-                  <FormErrorMessage>Please select a role</FormErrorMessage>
-                </FormControl>
-              )
-            }}
-          />
-          <Controller
-            control={control}
-            name='type'
-            render={({ field }) => {
-              return (
-                <FormControl isRequired as='fieldset' isInvalid={!!errors.type}>
-                  <FormLabel as='legend'>Type</FormLabel>
-                  <Select background='white' {...field}>
-                    <option value=''>Please select</option>
-                    {taxonomy?._document?.type?.allowed_values.map((option) => (
-                      <option key={option} value={option}>
-                        {option}
-                      </option>
-                    ))}
-                  </Select>
-                  <FormErrorMessage>Please select a type</FormErrorMessage>
-                </FormControl>
-              )
-            }}
-          />
+          {taxonomy?._document?.role && (
+            <Controller
+              control={control}
+              name='role'
+              render={({ field }) => {
+                return (
+                  <FormControl
+                    isRequired={!!taxonomy?._document?.role}
+                    as='fieldset'
+                    isInvalid={!!errors.role}
+                  >
+                    <FormLabel as='legend'>Role</FormLabel>
+                    <Select background='white' {...field}>
+                      <option value=''>Please select</option>
+                      {taxonomy?._document?.role?.allowed_values.map(
+                        (option) => (
+                          <option key={option} value={option}>
+                            {option}
+                          </option>
+                        ),
+                      )}
+                    </Select>
+                    <FormErrorMessage>Please select a role</FormErrorMessage>
+                  </FormControl>
+                )
+              }}
+            />
+          )}
+          {taxonomy?._document?.type && (
+            <Controller
+              control={control}
+              name='type'
+              render={({ field }) => {
+                return (
+                  <FormControl
+                    isRequired={!!taxonomy?._document?.type}
+                    as='fieldset'
+                    isInvalid={!!errors.type}
+                  >
+                    <FormLabel as='legend'>Type</FormLabel>
+                    <Select background='white' {...field}>
+                      <option value=''>Please select</option>
+                      {taxonomy?._document?.type?.allowed_values.map(
+                        (option) => (
+                          <option key={option} value={option}>
+                            {option}
+                          </option>
+                        ),
+                      )}
+                    </Select>
+                    <FormErrorMessage>Please select a type</FormErrorMessage>
+                  </FormControl>
+                )
+              }}
+            />
+          )}
           <Controller
             control={control}
             name='variant_name'

--- a/src/components/forms/DocumentForm.tsx
+++ b/src/components/forms/DocumentForm.tsx
@@ -56,6 +56,8 @@ export const DocumentForm = ({
   const { config, loading: configLoading, error: configError } = useConfig()
   const toast = useToast()
   const [formError, setFormError] = useState<IError | null | undefined>()
+  const renderRoleSelector = Boolean(taxonomy?._document?.role)
+  const renderTypeSelector = Boolean(taxonomy?._document?.type)
   const {
     control,
     register,
@@ -64,6 +66,10 @@ export const DocumentForm = ({
     formState: { errors, isSubmitting },
   } = useForm({
     resolver: yupResolver(documentSchema),
+    context: {
+      isTypeRequired: renderTypeSelector,
+      isRoleRequired: renderRoleSelector,
+    },
   })
   const handleFormSubmission = async (formData: IDocumentFormPost) => {
     setFormError(null)
@@ -71,7 +77,8 @@ export const DocumentForm = ({
     const convertToModified = (
       data: IDocumentFormPost,
     ): IDocumentFormPostModified => {
-      const metadata: IDocumentMetadata = { role: [], type: [] }
+      const metadata: IDocumentMetadata = {}
+
       if (data.role) {
         metadata.role = [data.role]
       }
@@ -203,14 +210,14 @@ export const DocumentForm = ({
               {errors.source_url && errors.source_url.message}
             </FormErrorMessage>
           </FormControl>
-          {taxonomy?._document?.role && (
+          {renderRoleSelector && (
             <Controller
               control={control}
               name='role'
               render={({ field }) => {
                 return (
                   <FormControl
-                    isRequired={!!taxonomy?._document?.role}
+                    isRequired={!!renderRoleSelector}
                     as='fieldset'
                     isInvalid={!!errors.role}
                   >
@@ -231,14 +238,14 @@ export const DocumentForm = ({
               }}
             />
           )}
-          {taxonomy?._document?.type && (
+          {renderTypeSelector && (
             <Controller
               control={control}
               name='type'
               render={({ field }) => {
                 return (
                   <FormControl
-                    isRequired={!!taxonomy?._document?.type}
+                    isRequired={!!renderTypeSelector}
                     as='fieldset'
                     isInvalid={!!errors.type}
                   >

--- a/src/components/forms/DocumentForm.tsx
+++ b/src/components/forms/DocumentForm.tsx
@@ -166,8 +166,6 @@ export const DocumentForm = ({
     }
   }, [loadedDocument, familyId, reset])
 
-  console.log(taxonomy)
-
   return (
     <>
       {invalidDocumentCreation && (

--- a/src/components/forms/EventForm.tsx
+++ b/src/components/forms/EventForm.tsx
@@ -12,6 +12,7 @@ import {
   IEventFormPut,
   IConfigTaxonomyCCLW,
   IConfigTaxonomyUNFCCC,
+  IConfigTaxonomyMCF,
 } from '@/interfaces'
 import { eventSchema } from '@/schemas/eventSchema'
 import { createEvent, updateEvent } from '@/api/Events'
@@ -34,7 +35,7 @@ type TProps = {
   familyId: string
   canModify: boolean
   event?: IEvent
-  taxonomy?: IConfigTaxonomyCCLW | IConfigTaxonomyUNFCCC
+  taxonomy?: IConfigTaxonomyCCLW | IConfigTaxonomyUNFCCC | IConfigTaxonomyMCF
   onSuccess?: (eventId: string) => void
 }
 

--- a/src/hooks/useTaxonomy.ts
+++ b/src/hooks/useTaxonomy.ts
@@ -1,9 +1,16 @@
-import { IConfigTaxonomyCCLW, IConfigTaxonomyUNFCCC } from '@/interfaces/Config'
+import {
+  IConfigTaxonomyCCLW,
+  IConfigTaxonomyMCF,
+  IConfigTaxonomyUNFCCC,
+} from '@/interfaces/Config'
 import { useMemo } from 'react'
 
 const useTaxonomy = (
   corpus_type?: string,
-  corpus_taxonomy?: IConfigTaxonomyCCLW | IConfigTaxonomyUNFCCC,
+  corpus_taxonomy?:
+    | IConfigTaxonomyCCLW
+    | IConfigTaxonomyUNFCCC
+    | IConfigTaxonomyMCF,
 ) => {
   return useMemo(() => {
     if (corpus_type === 'Law and Policies')

--- a/src/interfaces/Config.ts
+++ b/src/interfaces/Config.ts
@@ -51,10 +51,35 @@ export interface IConfigTaxonomyUNFCCC {
   _document: IConfigDocumentMetadata
 }
 
-export interface IConfigDocumentMetadata {
-  role: IConfigMeta
-  type: IConfigMeta
+export interface IConfigTaxonomyMCF {
+  approved_ref?: IConfigMeta
+  event_type: IConfigMeta
+  focal_area?: IConfigMeta
+  implementing_agency: IConfigMeta
+  project_id: IConfigMeta
+  project_url: IConfigMeta
+  project_value_co_financing: IConfigMeta
+  project_value_fund_spend: IConfigMeta
+  region: IConfigMeta
+  result_area?: IConfigMeta
+  result_type?: IConfigMeta
+  sector?: IConfigMeta
+  status: IConfigMeta
+  theme?: IConfigMeta
+  _document: IConfigDocumentMetadata
+  _event: IConfigEventMetadata
 }
+
+export interface IConfigDocumentMetadata {
+  role?: IConfigMeta
+  type?: IConfigMeta
+}
+
+export interface IConfigEventMetadata {
+  datetime_event_name: IConfigMeta
+  event_type: IConfigMeta
+}
+
 export interface IConfigOrganisationMetadata {
   name: string
   id: number
@@ -67,7 +92,7 @@ export interface IConfigCorpora {
   corpus_type: string
   corpus_type_description: string
   organisation: IConfigOrganisationMetadata
-  taxonomy: IConfigTaxonomyCCLW | IConfigTaxonomyUNFCCC
+  taxonomy: IConfigTaxonomyCCLW | IConfigTaxonomyUNFCCC | IConfigTaxonomyMCF
 }
 
 export interface IConfig {

--- a/src/interfaces/Config.ts
+++ b/src/interfaces/Config.ts
@@ -51,23 +51,44 @@ export interface IConfigTaxonomyUNFCCC {
   _document: IConfigDocumentMetadata
 }
 
-export interface IConfigTaxonomyMCF {
-  approved_ref?: IConfigMeta
+export type IConfigTaxonomyMCF =
+  | IConfigTaxonomyGCF
+  | IConfigTaxonomyAF
+  | IConfigTaxonomyGEF
+  | IConfigTaxonomyCIF
+
+type IConfigMCFBaseTaxonomy = {
   event_type: IConfigMeta
-  focal_area?: IConfigMeta
   implementing_agency: IConfigMeta
   project_id: IConfigMeta
   project_url: IConfigMeta
   project_value_co_financing: IConfigMeta
   project_value_fund_spend: IConfigMeta
   region: IConfigMeta
-  result_area?: IConfigMeta
-  result_type?: IConfigMeta
-  sector?: IConfigMeta
   status: IConfigMeta
-  theme?: IConfigMeta
   _document: IConfigDocumentMetadata
   _event: IConfigEventMetadata
+}
+
+// Extend base type for specific taxonomies
+type IConfigTaxonomyGCF = IConfigMCFBaseTaxonomy & {
+  approved_ref: IConfigMeta
+  result_area: IConfigMeta
+  result_type: IConfigMeta
+  sector: IConfigMeta
+  theme: IConfigMeta
+}
+
+type IConfigTaxonomyCIF = IConfigMCFBaseTaxonomy & {
+  sector: IConfigMeta
+}
+
+type IConfigTaxonomyGEF = IConfigMCFBaseTaxonomy & {
+  focal_area: IConfigMeta
+}
+
+type IConfigTaxonomyAF = IConfigMCFBaseTaxonomy & {
+  sector: IConfigMeta
 }
 
 export interface IConfigDocumentMetadata {

--- a/src/interfaces/Document.ts
+++ b/src/interfaces/Document.ts
@@ -38,6 +38,6 @@ export interface IDocumentFormPostModified {
 }
 
 export interface IDocumentMetadata {
-  role: string[]
-  type: string[]
+  role?: string[]
+  type?: string[]
 }

--- a/src/interfaces/Document.ts
+++ b/src/interfaces/Document.ts
@@ -21,8 +21,8 @@ export interface IDocument {
 export interface IDocumentFormPost {
   family_import_id: string
   variant_name?: string | null
-  role: string
-  type: string
+  role?: string
+  type?: string
   title: string
   source_url?: string | null
   user_language_name?: IConfigLanguageSorted | null

--- a/src/schemas/documentSchema.ts
+++ b/src/schemas/documentSchema.ts
@@ -4,8 +4,8 @@ export const documentSchema = yup
   .object({
     family_import_id: yup.string().required(),
     variant_name: yup.string().optional(),
-    role: yup.string().required(),
-    type: yup.string().required(),
+    role: yup.string().optional(),
+    type: yup.string().optional(),
     title: yup.string().required(),
     source_url: yup.string().url().optional(),
     user_language_name: yup

--- a/src/schemas/documentSchema.ts
+++ b/src/schemas/documentSchema.ts
@@ -4,8 +4,16 @@ export const documentSchema = yup
   .object({
     family_import_id: yup.string().required(),
     variant_name: yup.string().optional(),
-    role: yup.string().optional(),
-    type: yup.string().optional(),
+    role: yup.string().when('$isRoleRequired', {
+      is: true,
+      then: (schema) => schema.required(),
+      otherwise: (schema) => schema.notRequired(),
+    }),
+    type: yup.string().when('$isTypeRequired', {
+      is: true,
+      then: (schema) => schema.required(),
+      otherwise: (schema) => schema.notRequired(),
+    }),
     title: yup.string().required(),
     source_url: yup.string().url().optional(),
     user_language_name: yup

--- a/src/tests/components/forms/DocumentForm.test.tsx
+++ b/src/tests/components/forms/DocumentForm.test.tsx
@@ -1,6 +1,6 @@
 import { screen, waitFor, fireEvent, within } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import { unfcccConfigMock } from '../../utilsTest/mocks'
+import { mcfConfigMock, unfcccConfigMock } from '../../utilsTest/mocks'
 import { customRender } from '@/tests/utilsTest/render'
 import { DocumentForm } from '@/components/forms/DocumentForm'
 import { IDocument } from '@/interfaces'
@@ -33,7 +33,8 @@ const mockDocument: IDocument = {
   last_modified: '4/1/2021',
 }
 
-const mockTaxonomy = unfcccConfigMock.corpora[0].taxonomy
+const mockUNFCCCTaxonomy = unfcccConfigMock.corpora[0].taxonomy
+const mockMCFTaxonomy = mcfConfigMock.corpora[0].taxonomy
 
 describe('DocumentForm', () => {
   const onDocumentFormSuccess = vi.fn()
@@ -48,7 +49,7 @@ describe('DocumentForm', () => {
         familyId={'test'}
         onSuccess={onDocumentFormSuccess}
         document={mockDocument}
-        taxonomy={mockTaxonomy}
+        taxonomy={mockUNFCCCTaxonomy}
       />,
     )
 
@@ -73,7 +74,7 @@ describe('DocumentForm', () => {
         familyId={'test'}
         onSuccess={onDocumentFormSuccess}
         document={mockDocument}
-        taxonomy={mockTaxonomy}
+        taxonomy={mockUNFCCCTaxonomy}
       />,
     )
 
@@ -197,5 +198,45 @@ describe('DocumentForm', () => {
     await waitFor(() => {
       expect(onDocumentFormSuccess).toHaveBeenCalled()
     })
+  })
+
+  it('does not render document role controller if property does not exist on taxonomy', () => {
+    customRender(
+      <DocumentForm
+        familyId={'test'}
+        onSuccess={onDocumentFormSuccess}
+        document={mockDocument}
+        taxonomy={mockMCFTaxonomy}
+      />,
+    )
+
+    expect(screen.queryByText('Role')).not.toBeInTheDocument()
+  })
+
+  it('does not render document type controller if property does not exist on taxonomy', () => {
+    customRender(
+      <DocumentForm
+        familyId={'test'}
+        onSuccess={onDocumentFormSuccess}
+        document={mockDocument}
+        taxonomy={mockMCFTaxonomy}
+      />,
+    )
+
+    expect(screen.queryByText('Role')).not.toBeInTheDocument()
+  })
+
+  it('renders role and type controller if properties exist on taxonomy', () => {
+    customRender(
+      <DocumentForm
+        familyId={'test'}
+        onSuccess={onDocumentFormSuccess}
+        document={mockDocument}
+        taxonomy={mockUNFCCCTaxonomy}
+      />,
+    )
+
+    expect(screen.getByText('Role')).toBeInTheDocument()
+    expect(screen.getByText('Type')).toBeInTheDocument()
   })
 })

--- a/src/tests/components/forms/DocumentForm.test.tsx
+++ b/src/tests/components/forms/DocumentForm.test.tsx
@@ -223,7 +223,7 @@ describe('DocumentForm', () => {
       />,
     )
 
-    expect(screen.queryByText('Role')).not.toBeInTheDocument()
+    expect(screen.queryByText('Type')).not.toBeInTheDocument()
   })
 
   it('renders role and type controller if properties exist on taxonomy', () => {

--- a/src/tests/utilsTest/mocks.tsx
+++ b/src/tests/utilsTest/mocks.tsx
@@ -309,6 +309,83 @@ const mockUNFCCCConfig: IConfig = {
   ],
 }
 
+const mockMCFConfig: IConfig = {
+  ...mockConfig,
+  corpora: [
+    {
+      corpus_import_id: 'MCF.corpus.i00000001.n0000',
+      title: 'MCF Title',
+      description: 'Multilateral Climate Funds',
+      corpus_type: 'GEF',
+      corpus_type_description: 'GEF',
+      organisation: {
+        name: 'GEF',
+        id: 4,
+      },
+      taxonomy: {
+        region: {
+          allow_any: false,
+          allow_blanks: false,
+          allowed_values: ['Region 1', 'Region 2'],
+        },
+        sector: {
+          allow_any: false,
+          allow_blanks: false,
+          allowed_values: ['Sector 1', 'Sector 2'],
+        },
+        status: {
+          allow_any: false,
+          allow_blanks: false,
+          allowed_values: ['Status 1', 'Status 2'],
+        },
+        _document: {},
+        _event: {
+          datetime_event_name: {
+            allow_any: false,
+            allow_blanks: false,
+            allowed_values: ['Event 1'],
+          },
+          event_type: {
+            allow_any: false,
+            allow_blanks: false,
+            allowed_values: ['Event 1'],
+          },
+        },
+        event_type: {
+          allow_any: false,
+          allow_blanks: false,
+          allowed_values: ['Event 1', 'Event 2'],
+        },
+        project_id: {
+          allow_any: true,
+          allow_blanks: false,
+          allowed_values: ['Project ID 1', 'Project ID 2'],
+        },
+        project_url: {
+          allow_any: true,
+          allow_blanks: false,
+          allowed_values: ['Project URL', 'Project URL 2'],
+        },
+        implementing_agency: {
+          allow_any: false,
+          allow_blanks: false,
+          allowed_values: ['Agency 1', 'Agency 2'],
+        },
+        project_value_fund_spend: {
+          allow_any: true,
+          allow_blanks: false,
+          allowed_values: ['1000', '5000'],
+        },
+        project_value_co_financing: {
+          allow_any: true,
+          allow_blanks: false,
+          allowed_values: ['1000', '5000'],
+        },
+      },
+    },
+  ],
+}
+
 // Exports
 export const mockFamiliesData = [
   mockUNFCCCFamily,
@@ -320,6 +397,7 @@ export const mockFamiliesData = [
 export { mockConfig as configMock }
 export { mockCCLWConfig as cclwConfigMock }
 export { mockUNFCCCConfig as unfcccConfigMock }
+export { mockMCFConfig as mcfConfigMock }
 export { mockDocument }
 export { mockDocument2 }
 export { mockEvent }


### PR DESCRIPTION
# What's changed

Fix - document form parses mcf data/taxonomy without erroring

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
