### PR TITLE
Add GEF metadata rendering for families

### DIFF
--- a/src/interfaces/Family.ts
+++ b/src/interfaces/Family.ts
@@ -15,9 +15,8 @@ export interface ILawsAndPoliciesMetadata extends IMetadata {
   instrument: string[]
 }
 
-export interface IAFProjectsMetadata extends IMetadata {
+interface IMcfProjectsBaseMetadata extends IMetadata {
   region: string[]
-  sector: string[]
   implementing_agency: string[]
   status: string[]
   project_id: string[]
@@ -26,10 +25,20 @@ export interface IAFProjectsMetadata extends IMetadata {
   project_value_fund_spend: string[]
 }
 
+export interface IAFProjectsMetadata extends IMcfProjectsBaseMetadata {
+  sector: string[]
+}
+
+export interface IGefProjectsMetadata extends IMcfProjectsBaseMetadata {
+  focal_area: string[]
+}
+
+type TMcfProjectsMetadata = IAFProjectsMetadata | IGefProjectsMetadata
+
 export type TFamilyMetadata =
   | IInternationalAgreementsMetadata
   | ILawsAndPoliciesMetadata
-  | IAFProjectsMetadata
+  | TMcfProjectsMetadata
 
 // Read DTOs.
 interface IFamilyBase {
@@ -61,7 +70,20 @@ export interface ILawsAndPoliciesFamily extends IFamilyBase {
   metadata: ILawsAndPoliciesMetadata
 }
 
-export type TFamily = IInternationalAgreementsFamily | ILawsAndPoliciesFamily
+interface IAFProjectsFamily extends IFamilyBase {
+  metadata: IAFProjectsMetadata
+}
+
+interface IGefProjectsFamily extends IFamilyBase {
+  metadata: IGefProjectsMetadata
+}
+
+type TMcfFamily = IAFProjectsFamily | IGefProjectsFamily
+
+export type TFamily =
+  | IInternationalAgreementsFamily
+  | ILawsAndPoliciesFamily
+  | TMcfFamily
 
 // DTO for Create and Write.
 export interface IFamilyFormPostBase {
@@ -85,7 +107,12 @@ export interface IAFProjectsFamilyFormPost extends IFamilyFormPostBase {
   metadata: IAFProjectsMetadata
 }
 
+export interface IGefProjectsFamilyFormPost extends IFamilyFormPostBase {
+  metadata: IGefProjectsMetadata
+}
+
 export type TFamilyFormPost =
   | ILawsAndPoliciesFamilyFormPost
   | IInternationalAgreementsFamilyFormPost
   | IAFProjectsFamilyFormPost
+  | IGefProjectsFamilyFormPost

--- a/src/interfaces/Metadata.ts
+++ b/src/interfaces/Metadata.ts
@@ -90,6 +90,28 @@ export const CORPUS_METADATA_CONFIG: CorpusMetadataConfig = {
       'project_value_fund_spend',
     ],
   },
+  GEF: {
+    renderFields: {
+      region: { type: FieldType.MULTI_SELECT },
+      focal_area: { type: FieldType.MULTI_SELECT },
+      implementing_agency: { type: FieldType.MULTI_SELECT },
+      status: { type: FieldType.SINGLE_SELECT },
+      project_id: { type: FieldType.TEXT },
+      project_url: { type: FieldType.TEXT },
+      project_value_co_financing: { type: FieldType.NUMBER },
+      project_value_fund_spend: { type: FieldType.NUMBER },
+    },
+    validationFields: [
+      'project_id',
+      'project_url',
+      'region',
+      'focal_area',
+      'status',
+      'implementing_agency',
+      'project_value_co_financing',
+      'project_value_fund_spend',
+    ],
+  },
   default: {
     renderFields: {},
     validationFields: [],


### PR DESCRIPTION
# What's changed

Add GEF metadata rendering for families

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
