### PR TITLE
Feature/pdct 1753 render cif families in family form

### DIFF
--- a/src/components/forms/metadata-handlers/familyForm.ts
+++ b/src/components/forms/metadata-handlers/familyForm.ts
@@ -1,7 +1,7 @@
 import { IFamilyFormBase } from '@/components/forms/FamilyForm'
 import {
-  IAFProjectsFamilyFormPost,
-  IAFProjectsMetadata,
+  IAfProjectsFamilyFormPost,
+  IAfProjectsMetadata as IAfProjectsMetadata,
   IFamilyFormPostBase,
   IGefProjectsFamilyFormPost,
   IGefProjectsMetadata,
@@ -28,13 +28,11 @@ export type MetadataHandler<T extends TFamilyMetadata> = {
 }
 
 interface IFamilyFormIntlAgreements extends IFamilyFormBase {
-  // Intl. agreements
   author?: string
   author_type?: IChakraSelect
 }
 
 interface IFamilyFormLawsAndPolicies extends IFamilyFormBase {
-  // Laws and Policies
   topic?: IChakraSelect[]
   hazard?: IChakraSelect[]
   sector?: IChakraSelect[]
@@ -53,7 +51,7 @@ interface IFamilyFormMcfProjects extends IFamilyFormBase {
   project_value_fund_spend?: string
 }
 
-interface IFamilyFormAFProjects extends IFamilyFormMcfProjects {
+interface IFamilyFormAfProjects extends IFamilyFormMcfProjects {
   sector?: IChakraSelect[]
 }
 
@@ -74,7 +72,7 @@ interface IFamilyFormGefProjects extends IFamilyFormMcfProjects {
 }
 
 type TFamilyFormMcfProjects =
-  | IFamilyFormAFProjects
+  | IFamilyFormAfProjects
   | IFamilyFormGcfProjects
   | IFamilyFormGefProjects
   | IFamilyFormCifProjects
@@ -126,7 +124,7 @@ export const corpusMetadataHandlers: Record<
   },
   AF: {
     extractMetadata: (formData: TFamilyFormSubmit) => {
-      const afData = formData as IFamilyFormAFProjects
+      const afData = formData as IFamilyFormAfProjects
       return {
         region: afData.region?.map((region) => region.value) || [],
         sector: afData.sector?.map((sector) => sector.value) || [],
@@ -141,13 +139,13 @@ export const corpusMetadataHandlers: Record<
         project_value_fund_spend: afData.project_value_fund_spend
           ? [afData.project_value_fund_spend]
           : [0],
-      } as IAFProjectsMetadata
+      } as IAfProjectsMetadata
     },
     createSubmissionData: (baseData, metadata) =>
       ({
         ...baseData,
         metadata,
-      }) as IAFProjectsFamilyFormPost,
+      }) as IAfProjectsFamilyFormPost,
   },
   CIF: {
     extractMetadata: (formData: TFamilyFormSubmit) => {

--- a/src/components/forms/metadata-handlers/familyForm.ts
+++ b/src/components/forms/metadata-handlers/familyForm.ts
@@ -13,6 +13,8 @@ import {
   ILawsAndPoliciesFamilyFormPost,
   IGcfProjectsMetadata,
   IGcfProjectsFamilyFormPost,
+  ICifProjectsMetadata,
+  ICifProjectsFamilyFormPost,
 } from '../../../interfaces/Family'
 import { IChakraSelect } from '@/interfaces'
 
@@ -55,6 +57,10 @@ interface IFamilyFormAFProjects extends IFamilyFormMcfProjects {
   sector?: IChakraSelect[]
 }
 
+interface IFamilyFormCifProjects extends IFamilyFormMcfProjects {
+  sector?: IChakraSelect[]
+}
+
 interface IFamilyFormGcfProjects extends IFamilyFormMcfProjects {
   sector?: IChakraSelect[]
   result_area?: IChakraSelect[]
@@ -71,6 +77,7 @@ type TFamilyFormMcfProjects =
   | IFamilyFormAFProjects
   | IFamilyFormGcfProjects
   | IFamilyFormGefProjects
+  | IFamilyFormCifProjects
 
 export type TFamilyFormSubmit =
   | IFamilyFormLawsAndPolicies
@@ -141,6 +148,31 @@ export const corpusMetadataHandlers: Record<
         ...baseData,
         metadata,
       }) as IAFProjectsFamilyFormPost,
+  },
+  CIF: {
+    extractMetadata: (formData: TFamilyFormSubmit) => {
+      const cifData = formData as IFamilyFormCifProjects
+      return {
+        region: cifData.region?.map((region) => region.value) || [],
+        sector: cifData.sector?.map((sector) => sector.value) || [],
+        implementing_agency:
+          cifData.implementing_agency?.map((agency) => agency.value) || [],
+        status: cifData.status ? [cifData.status?.value] : [],
+        project_id: cifData.project_id ? [cifData.project_id] : [],
+        project_url: cifData.project_url ? [cifData.project_url] : [],
+        project_value_co_financing: cifData.project_value_co_financing
+          ? [cifData.project_value_co_financing]
+          : [0],
+        project_value_fund_spend: cifData.project_value_fund_spend
+          ? [cifData.project_value_fund_spend]
+          : [0],
+      } as ICifProjectsMetadata
+    },
+    createSubmissionData: (baseData, metadata) =>
+      ({
+        ...baseData,
+        metadata,
+      }) as ICifProjectsFamilyFormPost,
   },
   GCF: {
     extractMetadata: (formData: TFamilyFormSubmit) => {

--- a/src/components/forms/metadata-handlers/familyForm.ts
+++ b/src/components/forms/metadata-handlers/familyForm.ts
@@ -1,7 +1,7 @@
 import { IFamilyFormBase } from '@/components/forms/FamilyForm'
 import {
   IAfProjectsFamilyFormPost,
-  IAfProjectsMetadata as IAfProjectsMetadata,
+  IAfProjectsMetadata,
   IFamilyFormPostBase,
   IGefProjectsFamilyFormPost,
   IGefProjectsMetadata,

--- a/src/interfaces/Family.ts
+++ b/src/interfaces/Family.ts
@@ -25,7 +25,7 @@ interface IMcfProjectsBaseMetadata extends IMetadata {
   project_value_fund_spend: string[]
 }
 
-export interface IAFProjectsMetadata extends IMcfProjectsBaseMetadata {
+export interface IAfProjectsMetadata extends IMcfProjectsBaseMetadata {
   sector: string[]
 }
 
@@ -46,7 +46,7 @@ export interface IGcfProjectsMetadata extends IMcfProjectsBaseMetadata {
 }
 
 type TMcfProjectsMetadata =
-  | IAFProjectsMetadata
+  | IAfProjectsMetadata
   | IGefProjectsMetadata
   | IGcfProjectsMetadata
   | ICifProjectsMetadata
@@ -86,8 +86,8 @@ export interface ILawsAndPoliciesFamily extends IFamilyBase {
   metadata: ILawsAndPoliciesMetadata
 }
 
-interface IAFProjectsFamily extends IFamilyBase {
-  metadata: IAFProjectsMetadata
+interface IAfProjectsFamily extends IFamilyBase {
+  metadata: IAfProjectsMetadata
 }
 
 interface ICifProjectsFamily extends IFamilyBase {
@@ -103,7 +103,7 @@ interface IGcfProjectsFamily extends IFamilyBase {
 }
 
 type TMcfFamily =
-  | IAFProjectsFamily
+  | IAfProjectsFamily
   | IGefProjectsFamily
   | IGcfProjectsFamily
   | ICifProjectsFamily
@@ -131,8 +131,8 @@ export interface IInternationalAgreementsFamilyFormPost
   extends IFamilyFormPostBase {
   metadata: IInternationalAgreementsMetadata
 }
-export interface IAFProjectsFamilyFormPost extends IFamilyFormPostBase {
-  metadata: IAFProjectsMetadata
+export interface IAfProjectsFamilyFormPost extends IFamilyFormPostBase {
+  metadata: IAfProjectsMetadata
 }
 
 export interface ICifProjectsFamilyFormPost extends IFamilyFormPostBase {
@@ -148,7 +148,7 @@ export interface IGcfProjectsFamilyFormPost extends IFamilyFormPostBase {
 }
 
 type TMcfFamilyFormPost =
-  | IAFProjectsFamilyFormPost
+  | IAfProjectsFamilyFormPost
   | IGefProjectsFamilyFormPost
   | IGcfProjectsFamilyFormPost
   | ICifProjectsFamilyFormPost

--- a/src/interfaces/Family.ts
+++ b/src/interfaces/Family.ts
@@ -29,6 +29,10 @@ export interface IAFProjectsMetadata extends IMcfProjectsBaseMetadata {
   sector: string[]
 }
 
+export interface ICifProjectsMetadata extends IMcfProjectsBaseMetadata {
+  sector: string[]
+}
+
 export interface IGefProjectsMetadata extends IMcfProjectsBaseMetadata {
   focal_area: string[]
 }
@@ -45,6 +49,7 @@ type TMcfProjectsMetadata =
   | IAFProjectsMetadata
   | IGefProjectsMetadata
   | IGcfProjectsMetadata
+  | ICifProjectsMetadata
 
 export type TFamilyMetadata =
   | IInternationalAgreementsMetadata
@@ -85,6 +90,10 @@ interface IAFProjectsFamily extends IFamilyBase {
   metadata: IAFProjectsMetadata
 }
 
+interface ICifProjectsFamily extends IFamilyBase {
+  metadata: ICifProjectsMetadata
+}
+
 interface IGefProjectsFamily extends IFamilyBase {
   metadata: IGefProjectsMetadata
 }
@@ -93,7 +102,11 @@ interface IGcfProjectsFamily extends IFamilyBase {
   metadata: IGcfProjectsMetadata
 }
 
-type TMcfFamily = IAFProjectsFamily | IGefProjectsFamily | IGcfProjectsFamily
+type TMcfFamily =
+  | IAFProjectsFamily
+  | IGefProjectsFamily
+  | IGcfProjectsFamily
+  | ICifProjectsFamily
 
 export type TFamily =
   | IInternationalAgreementsFamily
@@ -122,6 +135,10 @@ export interface IAFProjectsFamilyFormPost extends IFamilyFormPostBase {
   metadata: IAFProjectsMetadata
 }
 
+export interface ICifProjectsFamilyFormPost extends IFamilyFormPostBase {
+  metadata: ICifProjectsMetadata
+}
+
 export interface IGefProjectsFamilyFormPost extends IFamilyFormPostBase {
   metadata: IGefProjectsMetadata
 }
@@ -134,6 +151,7 @@ type TMcfFamilyFormPost =
   | IAFProjectsFamilyFormPost
   | IGefProjectsFamilyFormPost
   | IGcfProjectsFamilyFormPost
+  | ICifProjectsFamilyFormPost
 
 export type TFamilyFormPost =
   | ILawsAndPoliciesFamilyFormPost

--- a/src/interfaces/Metadata.ts
+++ b/src/interfaces/Metadata.ts
@@ -90,6 +90,28 @@ export const CORPUS_METADATA_CONFIG: CorpusMetadataConfig = {
       'project_value_fund_spend',
     ],
   },
+  CIF: {
+    renderFields: {
+      region: { type: FieldType.MULTI_SELECT },
+      sector: { type: FieldType.MULTI_SELECT },
+      implementing_agency: { type: FieldType.MULTI_SELECT },
+      status: { type: FieldType.SINGLE_SELECT },
+      project_id: { type: FieldType.TEXT },
+      project_url: { type: FieldType.TEXT },
+      project_value_co_financing: { type: FieldType.NUMBER },
+      project_value_fund_spend: { type: FieldType.NUMBER },
+    },
+    validationFields: [
+      'project_id',
+      'project_url',
+      'region',
+      'sector',
+      'status',
+      'implementing_agency',
+      'project_value_co_financing',
+      'project_value_fund_spend',
+    ],
+  },
   GCF: {
     renderFields: {
       region: { type: FieldType.MULTI_SELECT },


### PR DESCRIPTION
# What's changed

Add CIF metadata rendering to family form

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
