### PR TITLE
Fix uncontrolled controlled bug in dynamic metadata form

### DIFF
--- a/src/components/forms/DynamicMetadataFields.tsx
+++ b/src/components/forms/DynamicMetadataFields.tsx
@@ -44,9 +44,21 @@ export const DynamicMetadataFields = <T extends FieldValues>({
     allow_blanks = true,
   } = taxonomyField
 
-  const renderField = () => {
+  const renderField = (isRequired: boolean) => {
     if (allow_any) {
-      return <TextField<T> name={fieldKey as Path<T>} control={control} />
+      console.log(
+        'Rendering the form fields, allow_any True:',
+        fieldKey,
+        fieldType,
+        taxonomyField,
+      )
+      return (
+        <TextField<T>
+          name={fieldKey as Path<T>}
+          control={control}
+          isRequired={isRequired}
+        />
+      )
     }
 
     switch (fieldType) {
@@ -58,6 +70,7 @@ export const DynamicMetadataFields = <T extends FieldValues>({
             control={control}
             options={allowed_values}
             isMulti={fieldType === FieldType.MULTI_SELECT}
+            isRequired={isRequired}
           />
         )
       case FieldType.NUMBER:
@@ -66,11 +79,18 @@ export const DynamicMetadataFields = <T extends FieldValues>({
             name={fieldKey as Path<T>}
             control={control}
             type='number'
+            isRequired={isRequired}
           />
         )
       case FieldType.TEXT:
       default:
-        return <TextField<T> name={fieldKey as Path<T>} control={control} />
+        return (
+          <TextField<T>
+            name={fieldKey as Path<T>}
+            control={control}
+            isRequired={isRequired}
+          />
+        )
     }
   }
 
@@ -85,7 +105,7 @@ export const DynamicMetadataFields = <T extends FieldValues>({
           You are able to search and can select multiple options
         </FormHelperText>
       )}
-      {renderField()}
+      {renderField(isRequired)}
       <FormErrorMessage>
         {errors[fieldKey] && `${fieldKey} is required`}
       </FormErrorMessage>

--- a/src/components/forms/DynamicMetadataFields.tsx
+++ b/src/components/forms/DynamicMetadataFields.tsx
@@ -1,9 +1,4 @@
-import {
-  FormControl,
-  FormLabel,
-  FormErrorMessage,
-  FormHelperText,
-} from '@chakra-ui/react'
+import { FormControl, FormErrorMessage, FormHelperText } from '@chakra-ui/react'
 import { Control, FieldErrors, FieldValues, Path } from 'react-hook-form'
 import { FieldType } from '@/interfaces/Metadata'
 import { formatFieldLabel } from '@/utils/metadataUtils'
@@ -44,19 +39,17 @@ export const DynamicMetadataFields = <T extends FieldValues>({
     allow_blanks = true,
   } = taxonomyField
 
-  const renderField = (isRequired: boolean) => {
+  // Explicitly log the requirement logic
+  const isRequired = !allow_blanks
+
+  const renderField = () => {
     if (allow_any) {
-      console.log(
-        'Rendering the form fields, allow_any True:',
-        fieldKey,
-        fieldType,
-        taxonomyField,
-      )
       return (
         <TextField<T>
           name={fieldKey as Path<T>}
           control={control}
           isRequired={isRequired}
+          label={formatFieldLabel(fieldKey)}
         />
       )
     }
@@ -71,6 +64,7 @@ export const DynamicMetadataFields = <T extends FieldValues>({
             options={allowed_values}
             isMulti={fieldType === FieldType.MULTI_SELECT}
             isRequired={isRequired}
+            label={formatFieldLabel(fieldKey)}
           />
         )
       case FieldType.NUMBER:
@@ -80,6 +74,7 @@ export const DynamicMetadataFields = <T extends FieldValues>({
             control={control}
             type='number'
             isRequired={isRequired}
+            label={formatFieldLabel(fieldKey)}
           />
         )
       case FieldType.TEXT:
@@ -89,23 +84,20 @@ export const DynamicMetadataFields = <T extends FieldValues>({
             name={fieldKey as Path<T>}
             control={control}
             isRequired={isRequired}
+            label={formatFieldLabel(fieldKey)}
           />
         )
     }
   }
 
-  // Explicitly log the requirement logic
-  const isRequired = !allow_blanks
-
   return (
     <FormControl isInvalid={!!errors[fieldKey]} mb={4} isRequired={isRequired}>
-      <FormLabel>{formatFieldLabel(fieldKey)}</FormLabel>
       {fieldType === FieldType.MULTI_SELECT && (
         <FormHelperText mb={2}>
           You are able to search and can select multiple options
         </FormHelperText>
       )}
-      {renderField(isRequired)}
+      {renderField()}
       <FormErrorMessage>
         {errors[fieldKey] && `${fieldKey} is required`}
       </FormErrorMessage>

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -252,7 +252,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
       setFamilyDocuments(loadedFamily.documents || [])
       setFamilyEvents(loadedFamily.events || [])
 
-      // Pre-set the form values to that of the loaded family
+      // Pre-set the form values of the base family form (IFamilyFormBase) to that of the loaded family
       reset({
         title: loadedFamily.title,
         summary: loadedFamily.summary,

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -26,7 +26,11 @@ import { UnsavedChangesModal } from './modals/UnsavedChangesModal'
 import { ReadOnlyFields } from '../family/ReadOnlyFields'
 import { EntityEditDrawer } from '../drawers/EntityEditDrawer'
 
-import { TFamily, IFamilyFormPostBase } from '@/interfaces/Family'
+import {
+  TFamily,
+  IFamilyFormPostBase,
+  TFamilyMetadata,
+} from '@/interfaces/Family'
 import { canModify } from '@/utils/canModify'
 import { getCountries } from '@/utils/extractNestedGeographyData'
 import { decodeToken } from '@/utils/decodeToken'
@@ -50,6 +54,11 @@ import {
   getMetadataHandler,
   TFamilyFormSubmit,
 } from './metadata-handlers/familyForm'
+import {
+  CORPUS_METADATA_CONFIG,
+  FieldType,
+  IFormMetadata,
+} from '@/interfaces/Metadata'
 
 export interface IFamilyFormBase {
   title: string
@@ -73,6 +82,7 @@ const getCollection = (collectionId: string, collections: ICollection[]) => {
 export const FamilyForm = ({ family: loadedFamily }: TProps) => {
   const [isLeavingModalOpen, setIsLeavingModalOpen] = useState(false)
   const [isFormSubmitting, setIsFormSubmitting] = useState(false)
+  const [loadedAndReset, setLoadedAndReset] = useState(false)
   const { isOpen, onOpen, onClose } = useDisclosure()
   const navigate = useNavigate()
   const { config, error: configError, loading: configLoading } = useConfig()
@@ -252,6 +262,38 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
       setFamilyDocuments(loadedFamily.documents || [])
       setFamilyEvents(loadedFamily.events || [])
 
+      // PATRICK
+      // TODO: you might want to make this more elegant? I think it's fine tbh
+      let metadataValues: IFormMetadata = {}
+
+      if (loadedFamily?.metadata && corpusInfo) {
+        metadataValues = Object.entries(
+          loadedFamily.metadata as TFamilyMetadata,
+        ).reduce<IFormMetadata>((loadedMetadata, [key, value]) => {
+          const fieldConfig =
+            CORPUS_METADATA_CONFIG[corpusInfo.corpus_type]?.renderFields?.[key]
+          if (!fieldConfig) return loadedMetadata
+
+          if (fieldConfig.type === FieldType.SINGLE_SELECT) {
+            loadedMetadata[key] = value?.[0]
+              ? {
+                  value: value[0],
+                  label: value[0],
+                }
+              : undefined
+          } else if (fieldConfig.type === FieldType.MULTI_SELECT) {
+            loadedMetadata[key] = value?.map((v) => ({
+              value: v,
+              label: v,
+            }))
+          } else {
+            loadedMetadata[key] = value?.[0]
+          }
+
+          return loadedMetadata
+        }, {})
+      }
+
       // Pre-set the form values of the base family form (IFamilyFormBase) to that of the loaded family
       reset({
         title: loadedFamily.title,
@@ -282,9 +324,12 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
           .filter(
             (collection): collection is IChakraSelect => collection !== null,
           ),
+        ...metadataValues, // add the values for any metadata fields for the given family corpora type
       })
+
+      setLoadedAndReset(true)
     }
-  }, [config, loadedFamily, reset, isMCFCorpus, collections])
+  }, [config, loadedFamily, reset, isMCFCorpus, collections, corpusInfo])
 
   const onAddNewEntityClick = (entityType: TChildEntity) => {
     setEditingEntity(entityType)
@@ -500,7 +545,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
               />
             ) : null}
 
-            {corpusInfo && (
+            {loadedFamily && corpusInfo && loadedAndReset && (
               <>
                 <MetadataSection
                   corpusInfo={corpusInfo}

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -262,8 +262,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
       setFamilyDocuments(loadedFamily.documents || [])
       setFamilyEvents(loadedFamily.events || [])
 
-      // PATRICK
-      // TODO: you might want to make this more elegant? I think it's fine tbh
+      // TODO: move to utils function
       let metadataValues: IFormMetadata = {}
 
       if (loadedFamily?.metadata && corpusInfo) {

--- a/src/components/forms/fields/TextField.tsx
+++ b/src/components/forms/fields/TextField.tsx
@@ -23,6 +23,7 @@ export const TextField = <T extends FieldValues>({
   label,
   isRequired,
 }: TProps<T>) => {
+  console.log('TextField:', name, placeholder, label, isRequired)
   return (
     <Controller
       name={name}
@@ -31,7 +32,7 @@ export const TextField = <T extends FieldValues>({
         <FormControl isInvalid={!!error} isRequired={isRequired}>
           {label && <FormLabel>{label}</FormLabel>}
           <Input
-            {...field}
+            {...field} // This destructured object contains the value
             bg='white'
             type={type}
             placeholder={placeholder ?? `Enter ${name}`}

--- a/src/components/forms/fields/TextField.tsx
+++ b/src/components/forms/fields/TextField.tsx
@@ -23,13 +23,11 @@ export const TextField = <T extends FieldValues>({
   label,
   isRequired,
 }: TProps<T>) => {
-  // console.log('TextField:', name, placeholder, label, isRequired)
   return (
     <Controller
       name={name}
       control={control}
       render={({ field, fieldState: { error } }) => {
-        console.log(field)
         return (
           <FormControl isInvalid={!!error} isRequired={isRequired}>
             {label && <FormLabel>{label}</FormLabel>}

--- a/src/components/forms/fields/TextField.tsx
+++ b/src/components/forms/fields/TextField.tsx
@@ -23,23 +23,26 @@ export const TextField = <T extends FieldValues>({
   label,
   isRequired,
 }: TProps<T>) => {
-  console.log('TextField:', name, placeholder, label, isRequired)
+  // console.log('TextField:', name, placeholder, label, isRequired)
   return (
     <Controller
       name={name}
       control={control}
-      render={({ field, fieldState: { error } }) => (
-        <FormControl isInvalid={!!error} isRequired={isRequired}>
-          {label && <FormLabel>{label}</FormLabel>}
-          <Input
-            {...field} // This destructured object contains the value
-            bg='white'
-            type={type}
-            placeholder={placeholder ?? `Enter ${name}`}
-          />
-          {error && <FormErrorMessage>{error.message}</FormErrorMessage>}
-        </FormControl>
-      )}
+      render={({ field, fieldState: { error } }) => {
+        console.log(field)
+        return (
+          <FormControl isInvalid={!!error} isRequired={isRequired}>
+            {label && <FormLabel>{label}</FormLabel>}
+            <Input
+              {...field} // This destructured object contains the value
+              bg='white'
+              type={type}
+              placeholder={placeholder ?? `Enter ${name}`}
+            />
+            {error && <FormErrorMessage>{error.message}</FormErrorMessage>}
+          </FormControl>
+        )
+      }}
     />
   )
 }

--- a/src/components/forms/sections/MetadataSection.tsx
+++ b/src/components/forms/sections/MetadataSection.tsx
@@ -1,18 +1,8 @@
-// import { useEffect, useState } from 'react'
 import { Control, FieldErrors, UseFormReset } from 'react-hook-form'
 import { Box, Divider, AbsoluteCenter } from '@chakra-ui/react'
 import { DynamicMetadataFields } from '../DynamicMetadataFields'
-import {
-  CORPUS_METADATA_CONFIG,
-  FieldType,
-  // IFormMetadata,
-} from '@/interfaces/Metadata'
-import {
-  IConfigCorpora,
-  TFamily,
-  // TFamilyMetadata,
-  TTaxonomy,
-} from '@/interfaces'
+import { CORPUS_METADATA_CONFIG, FieldType } from '@/interfaces/Metadata'
+import { IConfigCorpora, TFamily, TTaxonomy } from '@/interfaces'
 import { IFamilyFormBase } from '../FamilyForm'
 
 type TProps = {

--- a/src/components/forms/sections/MetadataSection.tsx
+++ b/src/components/forms/sections/MetadataSection.tsx
@@ -1,16 +1,16 @@
-import { useEffect } from 'react'
+// import { useEffect, useState } from 'react'
 import { Control, FieldErrors, UseFormReset } from 'react-hook-form'
 import { Box, Divider, AbsoluteCenter } from '@chakra-ui/react'
 import { DynamicMetadataFields } from '../DynamicMetadataFields'
 import {
   CORPUS_METADATA_CONFIG,
   FieldType,
-  IFormMetadata,
+  // IFormMetadata,
 } from '@/interfaces/Metadata'
 import {
   IConfigCorpora,
   TFamily,
-  TFamilyMetadata,
+  // TFamilyMetadata,
   TTaxonomy,
 } from '@/interfaces'
 import { IFamilyFormBase } from '../FamilyForm'
@@ -29,51 +29,53 @@ export const MetadataSection = ({
   taxonomy,
   control,
   errors,
-  loadedFamily,
-  reset,
+  // loadedFamily,
+  // reset,
 }: TProps) => {
-  useEffect(() => {
-    if (loadedFamily?.metadata && corpusInfo) {
-      console.log('Populating the form fields')
+  // PATRICK: I don't think we needed to wait until here to do this work, so I've moved it to the reset in the parent FamilyForm
+  // useEffect(() => {
+  //   if (loadedFamily?.metadata && corpusInfo) {
+  //     console.log('Populating the form fields')
 
-      // This is populating the metadata form fields by transforming the metadata from the loaded family
-      // into the format that the form expects.
-      const metadataValues = Object.entries(
-        loadedFamily.metadata as TFamilyMetadata,
-      ).reduce<IFormMetadata>((loadedMetadata, [key, value]) => {
-        const fieldConfig =
-          CORPUS_METADATA_CONFIG[corpusInfo.corpus_type]?.renderFields?.[key]
-        if (!fieldConfig) return loadedMetadata
+  //     // This is populating the metadata form fields by transforming the metadata from the loaded family
+  //     // into the format that the form expects.
+  //     const metadataValues = Object.entries(
+  //       loadedFamily.metadata as TFamilyMetadata,
+  //     ).reduce<IFormMetadata>((loadedMetadata, [key, value]) => {
+  //       const fieldConfig =
+  //         CORPUS_METADATA_CONFIG[corpusInfo.corpus_type]?.renderFields?.[key]
+  //       if (!fieldConfig) return loadedMetadata
 
-        if (fieldConfig.type === FieldType.SINGLE_SELECT) {
-          loadedMetadata[key] = value?.[0]
-            ? {
-                value: value[0],
-                label: value[0],
-              }
-            : undefined
-        } else if (fieldConfig.type === FieldType.MULTI_SELECT) {
-          loadedMetadata[key] = value?.map((v) => ({
-            value: v,
-            label: v,
-          }))
-        } else {
-          loadedMetadata[key] = value?.[0]
-        }
+  //       if (fieldConfig.type === FieldType.SINGLE_SELECT) {
+  //         loadedMetadata[key] = value?.[0]
+  //           ? {
+  //               value: value[0],
+  //               label: value[0],
+  //             }
+  //           : undefined
+  //       } else if (fieldConfig.type === FieldType.MULTI_SELECT) {
+  //         loadedMetadata[key] = value?.map((v) => ({
+  //           value: v,
+  //           label: v,
+  //         }))
+  //       } else {
+  //         loadedMetadata[key] = value?.[0]
+  //       }
 
-        return loadedMetadata
-      }, {})
+  //       return loadedMetadata
+  //     }, {})
 
-      reset((formValues: IFamilyFormBase) => ({
-        ...formValues,
-        ...metadataValues,
-      }))
-    }
-  }, [loadedFamily, corpusInfo, reset])
+  //     reset((formValues: IFamilyFormBase) => ({
+  //       ...formValues,
+  //       ...metadataValues,
+  //     }))
+
+  //     setIsMetaDataReady(true)
+  //     console.log('metadataValues:', metadataValues)
+  //   }
+  // }, [loadedFamily, corpusInfo, reset])
 
   if (!corpusInfo || !taxonomy) return null
-
-  if (!loadedFamily?.metadata) return null // TODO Remove
 
   return (
     <>

--- a/src/components/forms/sections/MetadataSection.tsx
+++ b/src/components/forms/sections/MetadataSection.tsx
@@ -34,6 +34,10 @@ export const MetadataSection = ({
 }: TProps) => {
   useEffect(() => {
     if (loadedFamily?.metadata && corpusInfo) {
+      console.log('Populating the form fields')
+
+      // This is populating the metadata form fields by transforming the metadata from the loaded family
+      // into the format that the form expects.
       const metadataValues = Object.entries(
         loadedFamily.metadata as TFamilyMetadata,
       ).reduce<IFormMetadata>((loadedMetadata, [key, value]) => {
@@ -69,6 +73,8 @@ export const MetadataSection = ({
 
   if (!corpusInfo || !taxonomy) return null
 
+  if (!loadedFamily?.metadata) return null // TODO Remove
+
   return (
     <>
       <Box position='relative' padding='10'>
@@ -81,6 +87,7 @@ export const MetadataSection = ({
         (CORPUS_METADATA_CONFIG[corpusInfo.corpus_type]?.renderFields ||
           {}) as Record<string, { type: FieldType }>,
       ).map(([fieldKey, fieldConfig]) => (
+        // TODO Check here if undefined is being passed in at any point before the real value is plugged in
         <DynamicMetadataFields
           key={fieldKey}
           fieldKey={fieldKey}

--- a/src/components/forms/sections/MetadataSection.tsx
+++ b/src/components/forms/sections/MetadataSection.tsx
@@ -29,52 +29,7 @@ export const MetadataSection = ({
   taxonomy,
   control,
   errors,
-  // loadedFamily,
-  // reset,
 }: TProps) => {
-  // PATRICK: I don't think we needed to wait until here to do this work, so I've moved it to the reset in the parent FamilyForm
-  // useEffect(() => {
-  //   if (loadedFamily?.metadata && corpusInfo) {
-  //     console.log('Populating the form fields')
-
-  //     // This is populating the metadata form fields by transforming the metadata from the loaded family
-  //     // into the format that the form expects.
-  //     const metadataValues = Object.entries(
-  //       loadedFamily.metadata as TFamilyMetadata,
-  //     ).reduce<IFormMetadata>((loadedMetadata, [key, value]) => {
-  //       const fieldConfig =
-  //         CORPUS_METADATA_CONFIG[corpusInfo.corpus_type]?.renderFields?.[key]
-  //       if (!fieldConfig) return loadedMetadata
-
-  //       if (fieldConfig.type === FieldType.SINGLE_SELECT) {
-  //         loadedMetadata[key] = value?.[0]
-  //           ? {
-  //               value: value[0],
-  //               label: value[0],
-  //             }
-  //           : undefined
-  //       } else if (fieldConfig.type === FieldType.MULTI_SELECT) {
-  //         loadedMetadata[key] = value?.map((v) => ({
-  //           value: v,
-  //           label: v,
-  //         }))
-  //       } else {
-  //         loadedMetadata[key] = value?.[0]
-  //       }
-
-  //       return loadedMetadata
-  //     }, {})
-
-  //     reset((formValues: IFamilyFormBase) => ({
-  //       ...formValues,
-  //       ...metadataValues,
-  //     }))
-
-  //     setIsMetaDataReady(true)
-  //     console.log('metadataValues:', metadataValues)
-  //   }
-  // }, [loadedFamily, corpusInfo, reset])
-
   if (!corpusInfo || !taxonomy) return null
 
   return (
@@ -89,7 +44,6 @@ export const MetadataSection = ({
         (CORPUS_METADATA_CONFIG[corpusInfo.corpus_type]?.renderFields ||
           {}) as Record<string, { type: FieldType }>,
       ).map(([fieldKey, fieldConfig]) => (
-        // TODO Check here if undefined is being passed in at any point before the real value is plugged in
         <DynamicMetadataFields
           key={fieldKey}
           fieldKey={fieldKey}


### PR DESCRIPTION
# What's changed

Fix uncontrolled controlled bug in dynamic metadata form

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
