### PR TITLE
Make sure finances are sent to API as string

### DIFF
--- a/src/components/forms/metadata-handlers/familyForm.ts
+++ b/src/components/forms/metadata-handlers/familyForm.ts
@@ -133,12 +133,14 @@ export const corpusMetadataHandlers: Record<
         status: afData.status ? [afData.status?.value] : [],
         project_id: afData.project_id ? [afData.project_id] : [],
         project_url: afData.project_url ? [afData.project_url] : [],
-        project_value_co_financing: afData.project_value_co_financing
-          ? [afData.project_value_co_financing]
-          : [0],
-        project_value_fund_spend: afData.project_value_fund_spend
-          ? [afData.project_value_fund_spend]
-          : [0],
+        project_value_co_financing:
+          afData.project_value_co_financing !== undefined
+            ? [`${afData.project_value_co_financing}`]
+            : [],
+        project_value_fund_spend:
+          afData.project_value_fund_spend !== undefined
+            ? [`${afData.project_value_fund_spend}`]
+            : [],
       } as IAfProjectsMetadata
     },
     createSubmissionData: (baseData, metadata) =>
@@ -158,12 +160,14 @@ export const corpusMetadataHandlers: Record<
         status: cifData.status ? [cifData.status?.value] : [],
         project_id: cifData.project_id ? [cifData.project_id] : [],
         project_url: cifData.project_url ? [cifData.project_url] : [],
-        project_value_co_financing: cifData.project_value_co_financing
-          ? [cifData.project_value_co_financing]
-          : [0],
-        project_value_fund_spend: cifData.project_value_fund_spend
-          ? [cifData.project_value_fund_spend]
-          : [0],
+        project_value_co_financing:
+          cifData.project_value_co_financing !== undefined
+            ? [`${cifData.project_value_co_financing}`]
+            : [],
+        project_value_fund_spend:
+          cifData.project_value_fund_spend !== undefined
+            ? [`${cifData.project_value_fund_spend}`]
+            : [],
       } as ICifProjectsMetadata
     },
     createSubmissionData: (baseData, metadata) =>
@@ -183,12 +187,14 @@ export const corpusMetadataHandlers: Record<
         status: gcfData.status ? [gcfData.status?.value] : [],
         project_id: gcfData.project_id ? [gcfData.project_id] : [],
         project_url: gcfData.project_url ? [gcfData.project_url] : [],
-        project_value_co_financing: gcfData.project_value_co_financing
-          ? [gcfData.project_value_co_financing]
-          : [0],
-        project_value_fund_spend: gcfData.project_value_fund_spend
-          ? [gcfData.project_value_fund_spend]
-          : [0],
+        project_value_co_financing:
+          gcfData.project_value_co_financing !== undefined
+            ? [`${gcfData.project_value_co_financing}`]
+            : [],
+        project_value_fund_spend:
+          gcfData.project_value_fund_spend !== undefined
+            ? [`${gcfData.project_value_fund_spend}`]
+            : [],
         approved_ref: gcfData.approved_ref ? [gcfData.approved_ref] : [],
         result_area:
           gcfData.result_area?.map((result_area) => result_area.value) || [],
@@ -215,12 +221,14 @@ export const corpusMetadataHandlers: Record<
         status: gefData.status ? [gefData.status?.value] : [],
         project_id: gefData.project_id ? [gefData.project_id] : [],
         project_url: gefData.project_url ? [gefData.project_url] : [],
-        project_value_co_financing: gefData.project_value_co_financing
-          ? [gefData.project_value_co_financing]
-          : [0],
-        project_value_fund_spend: gefData.project_value_fund_spend
-          ? [gefData.project_value_fund_spend]
-          : [0],
+        project_value_co_financing:
+          gefData.project_value_co_financing !== undefined
+            ? [`${gefData.project_value_co_financing}`]
+            : [],
+        project_value_fund_spend:
+          gefData.project_value_fund_spend !== undefined
+            ? [`${gefData.project_value_fund_spend}`]
+            : [],
       } as IGefProjectsMetadata
     },
     createSubmissionData: (baseData, metadata) =>


### PR DESCRIPTION
# What's changed

Make sure finances are sent to API as string

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
