### PR TITLE
Default TextField to empty string value if non passed

### DIFF
--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -327,6 +327,8 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
       })
 
       setLoadedAndReset(true)
+    } else {
+      setLoadedAndReset(true)
     }
   }, [config, loadedFamily, reset, isMCFCorpus, collections, corpusInfo])
 
@@ -544,7 +546,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
               />
             ) : null}
 
-            {loadedFamily && corpusInfo && loadedAndReset && (
+            {corpusInfo && loadedAndReset && (
               <>
                 <MetadataSection
                   corpusInfo={corpusInfo}

--- a/src/components/forms/fields/TextField.tsx
+++ b/src/components/forms/fields/TextField.tsx
@@ -46,6 +46,7 @@ export const TextField = <T extends FieldValues>({
               bg='white'
               type={type}
               placeholder={placeholder ?? `Enter ${name}`}
+              value={field.value ?? ''} // this prevents the component changing from a controlled to uncontrolled component
             />
             {showHelperText && isDisabled && (
               <FormHelperText>You cannot edit this</FormHelperText>


### PR DESCRIPTION
# What's changed
- Resolves the javascript error in the console when on the family form (this should also resolve any issue related to the text input fields that have a similar error)

- Also contains drive-by fix for displaying metadata when creating a new family

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
