### PR TITLE
Fix category missing for MCF families

### DIFF
--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useMemo, useCallback } from 'react'
-import { useForm, SubmitHandler } from 'react-hook-form'
+import { useForm, SubmitHandler, SubmitErrorHandler } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import { useBlocker, useNavigate } from 'react-router-dom'
 import {
@@ -141,6 +141,9 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
     formState: { errors, isSubmitting, dirtyFields },
   } = useForm<TFamilyFormSubmit>({
     resolver: yupResolver<TFamilyFormSubmit>(validationSchema),
+    defaultValues: {
+      category: 'MCF', // Can we be smarter about this?
+    },
   })
 
   // Watch for corpus changes and update schema only when creating a new family
@@ -247,7 +250,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
     try {
       await handleFormSubmission(data)
     } catch (error) {
-      console.log('onSubmitErrorHandler', error)
+      console.error('onSubmit', error)
       setFormError(error as IError)
       toast({
         title: 'Form submission error',
@@ -256,6 +259,20 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
       })
     }
   }
+
+  const onSubmitErrorHandler: SubmitErrorHandler<TFamilyFormSubmit> =
+    useCallback(
+      (errors) => {
+        console.error('onSubmitErrorHandler', errors)
+        setFormError(errors as IError)
+        toast({
+          title: 'Form submission error',
+          description: (errors as IError).message,
+          status: 'error',
+        })
+      },
+      [toast],
+    )
 
   useEffect(() => {
     if (loadedFamily) {
@@ -464,7 +481,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
       )}
 
       {canLoadForm && (
-        <form onSubmit={handleSubmit(onSubmit)}>
+        <form onSubmit={handleSubmit(onSubmit, onSubmitErrorHandler)}>
           <VStack gap='4' mb={12} mt={4} align={'stretch'}>
             {formError && <ApiError error={formError} />}
 

--- a/src/interfaces/Family.ts
+++ b/src/interfaces/Family.ts
@@ -62,6 +62,7 @@ interface IFamilyBase {
   title: string
   summary: string
   geography: string
+  geographies: string[]
   category: string
   status: string
   slug: string
@@ -118,6 +119,7 @@ export interface IFamilyFormPostBase {
   title: string
   summary: string
   geography: string
+  geographies: string[]
   category: string
   collections: string[]
   corpus_import_id: string


### PR DESCRIPTION
# What's changed

Fix category missing for MCF families

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
