### PR TITLE
Feature/app 160 UI updates to the admin frontend mcf guidances

### DIFF
--- a/src/components/forms/DocumentForm.tsx
+++ b/src/components/forms/DocumentForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback, useMemo } from 'react'
 import { useForm, SubmitHandler, SubmitErrorHandler } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import {
@@ -66,6 +66,12 @@ export const DocumentForm = ({
     ? docTaxonomy?.type?.allowed_values || []
     : []
 
+  const isMCFCorpus = useMemo(() => {
+    return config?.corpora.some((corpus) =>
+      corpus?.corpus_import_id.startsWith('MCF'),
+    )
+  }, [config?.corpora])
+
   const {
     control,
     register,
@@ -78,6 +84,7 @@ export const DocumentForm = ({
     context: {
       isTypeRequired: renderTypeSelector,
       isRoleRequired: renderRoleSelector,
+      isMCFCorpus: isMCFCorpus,
     },
   })
 
@@ -252,7 +259,10 @@ export const DocumentForm = ({
             <Input bg='white' {...register('title')} />
           </FormControl>
 
-          <FormControl isInvalid={!!errors.source_url}>
+          <FormControl
+            isRequired={!!isMCFCorpus}
+            isInvalid={!!errors.source_url}
+          >
             <FormLabel>Source URL</FormLabel>
             <Input bg='white' {...register('source_url')} />
             <FormErrorMessage role='error'>

--- a/src/components/forms/DocumentForm.tsx
+++ b/src/components/forms/DocumentForm.tsx
@@ -260,6 +260,8 @@ export const DocumentForm = ({
           </FormControl>
 
           <FormControl
+            // MCF projects and documents are required fields, other corpora related documents are not.
+            // Hence marking this form input as required
             isRequired={!!isMCFCorpus}
             isInvalid={!!errors.source_url}
           >

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -185,8 +185,8 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
 
     const corpusAuthor = watchCorpus.label.replace('Guidance', '').trim()
     const corpusAuthorType = {
-      value: 'Intergovermental Organization',
-      label: 'Intergovermental Organization',
+      value: 'Intergovernmental Organization',
+      label: 'Intergovernmental Organization',
     }
 
     setValue('author', corpusAuthor)
@@ -563,27 +563,16 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
               name='category'
               label='Category'
               control={control}
-              options={
-                // These are the global family categories. We set MCF as the category directly
-                // in the form above if the family corpus is a MCF corpus.
-                isMCFCorpus
-                  ? [
-                      { value: 'MCF', label: 'Projects' },
-                      {
-                        value: 'Reports',
-                        label: 'Reports (Guidance)',
-                      },
-                    ]
-                  : [
-                      { value: 'Executive', label: 'Executive' },
-                      { value: 'Legislative', label: 'Legislative' },
-                      { value: 'UNFCCC', label: 'UNFCCC' },
-                      {
-                        value: 'Reports',
-                        label: 'Reports',
-                      },
-                    ]
-              }
+              options={[
+                { value: 'Executive', label: 'Executive' },
+                { value: 'Legislative', label: 'Legislative' },
+                { value: 'UNFCCC', label: 'UNFCCC' },
+                {
+                  value: 'Reports',
+                  label: 'Reports (Guidance)',
+                },
+                { value: 'MCF', label: 'MCF Projects' },
+              ]}
               rules={{ required: true }}
             />
 

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -171,6 +171,28 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
     )
   }, [config?.corpora])
 
+  useEffect(() => {
+    if (loadedFamily) {
+      return
+    }
+
+    if (
+      !isMCFCorpus ||
+      !watchCorpus?.label.toLowerCase().includes('guidance')
+    ) {
+      return
+    }
+
+    const corpusAuthor = watchCorpus.label.replace('Guidance', '').trim()
+    const corpusAuthorType = {
+      value: 'Intergovermental Organization',
+      label: 'Intergovermental Organization',
+    }
+
+    setValue('author', corpusAuthor)
+    setValue('author_type', corpusAuthorType)
+  }, [watchCorpus, isMCFCorpus, loadedFamily, setValue])
+
   const userAccess = useMemo(() => {
     const token = localStorage.getItem('token')
     if (!token) return { canModify: false, isSuperUser: false }

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -176,21 +176,16 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
       return
     }
 
-    if (
-      !isMCFCorpus ||
-      !watchCorpus?.label.toLowerCase().includes('guidance')
-    ) {
-      return
-    }
+    if (isMCFCorpus && watchCorpus?.label.toLowerCase().includes('guidance')) {
+      const corpusAuthor = watchCorpus?.label.replace('Guidance', '').trim()
+      const corpusAuthorType = {
+        value: 'Intergovernmental Organization',
+        label: 'Intergovernmental Organization',
+      }
 
-    const corpusAuthor = watchCorpus.label.replace('Guidance', '').trim()
-    const corpusAuthorType = {
-      value: 'Intergovernmental Organization',
-      label: 'Intergovernmental Organization',
+      setValue('author', corpusAuthor)
+      setValue('author_type', corpusAuthorType)
     }
-
-    setValue('author', corpusAuthor)
-    setValue('author_type', corpusAuthorType)
   }, [watchCorpus, isMCFCorpus, loadedFamily, setValue])
 
   const userAccess = useMemo(() => {

--- a/src/interfaces/Document.ts
+++ b/src/interfaces/Document.ts
@@ -1,4 +1,5 @@
-import { IChakraSelect } from '.'
+import * as Yup from 'yup'
+import { documentSchema } from '../schemas/documentSchema'
 
 export interface IDocument {
   import_id: string
@@ -18,21 +19,7 @@ export interface IDocument {
   last_modified: string
 }
 
-export interface IDocumentFormPost {
-  family_import_id: string
-  variant_name: IChakraSelect | null
-  role: {
-    label?: string
-    value?: string
-  } | null
-  type: {
-    label?: string
-    value?: string
-  } | null
-  title: string
-  source_url?: string | null
-  user_language_name: IChakraSelect | null
-}
+export type IDocumentFormPost = Yup.InferType<typeof documentSchema>
 
 export interface IDocumentFormPostModified {
   family_import_id: string

--- a/src/interfaces/Metadata.ts
+++ b/src/interfaces/Metadata.ts
@@ -125,7 +125,7 @@ export const CORPUS_METADATA_CONFIG: CorpusMetadataConfig = {
       project_url: { type: FieldType.TEXT },
       project_value_co_financing: { type: FieldType.NUMBER },
       project_value_fund_spend: { type: FieldType.NUMBER },
-      approved_ref: { type: FieldType.NUMBER },
+      approved_ref: { type: FieldType.TEXT },
     },
     validationFields: [
       'project_id',

--- a/src/schemas/documentSchema.ts
+++ b/src/schemas/documentSchema.ts
@@ -55,7 +55,7 @@ export const documentSchema = yup
       .nullable()
       .when('$isMCFCorpus', {
         is: true,
-        then: (schema) => schema.required('Source url is a required field'),
+        then: (schema) => schema.required('Source Url is a required field'),
         otherwise: (schema) => schema.notRequired(),
       }),
     user_language_name: yup

--- a/src/schemas/documentSchema.ts
+++ b/src/schemas/documentSchema.ts
@@ -49,7 +49,15 @@ export const documentSchema = yup
         otherwise: (schema) => schema.notRequired(),
       }),
     title: yup.string().required(),
-    source_url: yup.string().url().nullable(),
+    source_url: yup
+      .string()
+      .url()
+      .nullable()
+      .when('$isMCFCorpus', {
+        is: true,
+        then: (schema) => schema.required('Source url is a required field'),
+        otherwise: (schema) => schema.notRequired(),
+      }),
     user_language_name: yup
       .object({
         label: yup.string().required(),


### PR DESCRIPTION
# What's changed

Updates to the admin front

- driveby refactors
- fix: approved_ref was expecting num types instead of text/string
- feat: set url as required on documents for mcf corpora projects 
- feat: set default author type and author values for mcf guidances

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
