### PR TITLE
APP-177: Make geography filter on family list page support multi geos

### DIFF
--- a/src/api/Families.ts
+++ b/src/api/Families.ts
@@ -2,11 +2,11 @@ import { AxiosError } from 'axios'
 
 import API from '@/api'
 import { setToken } from '@/api/Auth'
-import { TFamily, IError, TFamilyFormPost } from '@/interfaces'
+import { IError, TFamily, TFamilyFormPost } from '@/interfaces'
 
 export type TFamilySearchQuery = {
   query?: string | null
-  geography?: string | null
+  geographies?: string[] | null
   status?: string | null
   title?: string | null
   description?: string | null
@@ -14,13 +14,13 @@ export type TFamilySearchQuery = {
 
 type TSearchParams = {
   q?: string
-  geography?: string
+  geography?: string[]
   status?: string
 }
 
 export async function getFamilies({
   query,
-  geography,
+  geographies,
   status,
 }: TFamilySearchQuery) {
   setToken(API)
@@ -28,8 +28,8 @@ export async function getFamilies({
   const searchParams: TSearchParams = {
     q: query ?? '',
   }
-  if (geography) {
-    searchParams['geography'] = geography
+  if (geographies) {
+    searchParams['geography'] = geographies
   }
   if (status) {
     searchParams['status'] = status
@@ -37,6 +37,7 @@ export async function getFamilies({
 
   const response = await API.get<TFamily[]>('/v1/families/', {
     params: searchParams,
+    paramsSerializer: { indexes: null }, // Allows multiple 'geography' param instances
   })
     .then((response) => {
       return response

--- a/src/components/lists/FamilyList.tsx
+++ b/src/components/lists/FamilyList.tsx
@@ -95,7 +95,8 @@ export default function FamilyList() {
   const toast = useToast()
   const [familyError, setFamilyError] = useState<string | null | undefined>()
   const [formError, setFormError] = useState<IError | null | undefined>()
-  const qGeographies = searchParams.getAll('geography')
+  // String so useEffect doesn't keep re-rendering (referential comparison)
+  const qGeographies = searchParams.getAll('geography').join(';')
 
   const userToken = useMemo(() => {
     const token = localStorage.getItem('token')
@@ -202,7 +203,8 @@ export default function FamilyList() {
   }, [config])
 
   useEffect(() => {
-    const convertedGeographies: IChakraSelect[] = qGeographies.map(
+    const geographiesArray = qGeographies ? qGeographies.split(';') : []
+    const convertedGeographies: IChakraSelect[] = geographiesArray.map(
       (geography) =>
         geographyOptions.find(
           (option) => option.value === geography || option.label === geography,


### PR DESCRIPTION
# What's changed

Adds support for displaying and filtering by multiple geographies on the families page:

- Added support for multiple `geography` params, which matches how the API is called with multiple geographies e.g. `?geography=United+Kingdom&geography=Ireland`.
- The geographies column shows a ChakraUI badge for each geography code (ISO 3166-1 Alpha-3), alphabetically sorted for consistency.
- Updated the geographies filter to accept multiple geographies, store them in state, and apply them to queries being made.
  - Known issue: The page loads after each change to the geographies filter, so it can take a moment to add multiple geographies. This could be fixed in the future (or insisted on by the reviewer now).
- Results show OR logic matches - if a family includes any of the filtered geographies, it will match and show.

Tested locally against staging admin.

<img width="903" alt="Screenshot 2025-01-23 at 14 58 17" src="https://github.com/user-attachments/assets/68c0720b-9b03-491f-992e-2e896dc31f17" />

## Proposed version

- [x] Minor version

Fixes [APP-177](https://linear.app/climate-policy-radar/issue/APP-177/show-multi-geos-in-geography-column-on-family-list-page)