### PR TITLE
feat: handle redirect blocker when the form is being submitted

### DIFF
--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -457,10 +457,13 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
     !configLoading && !collectionsLoading && !configError && !collectionsError
 
   const blocker = useBlocker(({ currentLocation, nextLocation }) => {
-    if (currentLocation.pathname !== nextLocation.pathname) {
-      return !isSubmitted && Object.keys(touchedFields).length > 0
-    }
-    return false
+    const isRouteChange = currentLocation.pathname !== nextLocation.pathname
+    const isFormBeingSubmitted = isSubmitted || isSubmitting
+    const shouldBlockRouteChange =
+      isRouteChange &&
+      !isFormBeingSubmitted &&
+      Object.keys(touchedFields).length > 0
+    return shouldBlockRouteChange
   })
 
   useEffect(() => {


### PR DESCRIPTION
- as the blocker is being triggered by the useEffect, when its a submitting state it tries to to block the route, which is not what we want to do. Ideally we would wait before we try and block the route - i.e not wrapped in a use effect like that but thats another pr.

# What's changed

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
