### PR TITLE
Fix: Document update fails with status code 503 when changing language

### DIFF
--- a/src/components/forms/DocumentForm.tsx
+++ b/src/components/forms/DocumentForm.tsx
@@ -164,7 +164,7 @@ export const DocumentForm = ({
         metadata: metadata,
         source_url: data.source_url || null,
         variant_name: data.variant_name?.value || null,
-        user_language_name: data.user_language_name?.value || null,
+        user_language_name: data.user_language_name?.label || null,
       }
     }
 


### PR DESCRIPTION
# What's changed

- our backend parsing/queries retrieve and filter the language model based on the language name and we are sending the language code, when trying to update the language specifically it fails at this[ function](https://github.com/climatepolicyradar/navigator-admin-backend/blob/e7ecee08f63924bf8173bb7fd7037d47a6aac103/app/repository/document.py#L357).

Updating the payload to use the language name (label) instead of the code (value) resolves this. 

![Screenshot 2025-02-03 at 16 02 47](https://github.com/user-attachments/assets/260eaa4a-6554-4a75-91fe-34287d9b92c9)

![Screenshot 2025-02-04 at 09 19 49](https://github.com/user-attachments/assets/bbe9f525-6597-4065-8964-8317f0a1d7d3)


## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
