### PR TITLE
Feature/app 133 update admin frontend corpora form to use all organisations

### DIFF
--- a/src/api/Organisations.ts
+++ b/src/api/Organisations.ts
@@ -1,0 +1,44 @@
+import { AxiosError } from 'axios'
+
+import API from '@/api'
+import { setToken } from '@/api/Auth'
+import { IError } from '@/interfaces'
+import { IOrganisation } from '@/interfaces/Organisation'
+
+export async function getOrganisations() {
+  setToken(API)
+
+  const response = await API.get<IOrganisation[]>('/v1/organisations')
+    .then((response) => {
+      return response.data
+    })
+    .catch((error: AxiosError<{ detail: string }>) => {
+      const e: IError = {
+        status: error.response?.status || 500,
+        detail: error.response?.data?.detail || 'Unknown error',
+        message: error.message,
+      }
+      throw e
+    })
+
+  return { response }
+}
+
+export async function getOrganisation(id: number) {
+  setToken(API)
+
+  const response = await API.get<IOrganisation>('/v1/organisations/' + id)
+    .then((response) => {
+      return response
+    })
+    .catch((error: AxiosError<{ detail: string }>) => {
+      const e: IError = {
+        status: error.response?.status || 500,
+        detail: error.response?.data?.detail || 'Unknown error',
+        message: error.message,
+      }
+      throw e
+    })
+
+  return { response }
+}

--- a/src/components/forms/CorpusForm.tsx
+++ b/src/components/forms/CorpusForm.tsx
@@ -326,6 +326,7 @@ export const CorpusForm = ({ corpus: loadedCorpus }: TProps) => {
       {configError && <ApiError error={configError} />}
       {configLoading && <FormLoader />}
       {corpusTypesError && <ApiError error={corpusTypesError} />}
+      {organisationsError && <ApiError error={organisationsError} />}
 
       <form onSubmit={handleSubmit(onSubmit, onSubmitErrorHandler)}>
         <VStack gap='4' mb={12} align={'stretch'}>
@@ -438,7 +439,7 @@ export const CorpusForm = ({ corpus: loadedCorpus }: TProps) => {
             </FormControl>
           )}
 
-          {!organisationsError && !organisationsLoading && (
+          {!organisationsLoading && (
             <Controller
               control={control}
               name='organisation_id'

--- a/src/components/forms/CorpusForm.tsx
+++ b/src/components/forms/CorpusForm.tsx
@@ -41,6 +41,7 @@ import { TextField } from './fields/TextField'
 import { ImportIdSection } from './sections/ImportIdSection'
 import { FormLoader } from '../feedback/FormLoader'
 import useCorpusTypes from '@/hooks/useCorpusTypes'
+import useOrganisations from '@/hooks/useOrganisations'
 
 type TProps = {
   corpus?: ICorpus
@@ -93,6 +94,11 @@ export const CorpusForm = ({ corpus: loadedCorpus }: TProps) => {
     error: corpusTypesError,
     loading: corpusTypesLoading,
   } = useCorpusTypes()
+  const {
+    organisations,
+    error: organisationsError,
+    loading: organisationsLoading,
+  } = useOrganisations()
 
   const initialDescription = useRef<string | undefined>(
     loadedCorpus?.corpus_type_description,
@@ -432,7 +438,7 @@ export const CorpusForm = ({ corpus: loadedCorpus }: TProps) => {
             </FormControl>
           )}
 
-          {config && !configLoading && (
+          {!organisationsError && !organisationsLoading && (
             <Controller
               control={control}
               name='organisation_id'
@@ -450,17 +456,13 @@ export const CorpusForm = ({ corpus: loadedCorpus }: TProps) => {
                       isMulti={false}
                       isSearchable={true}
                       options={Array.from(
-                        new Set(
-                          config?.corpora?.map(
-                            (corpus) => corpus.organisation?.id,
-                          ),
-                        ),
+                        new Set(organisations.map((corpus) => corpus?.id)),
                       ).map((id) => {
-                        const corpus = config?.corpora?.find(
-                          (corpus) => corpus.organisation?.id === id,
+                        const corpus = organisations.find(
+                          (corpus) => corpus?.id === id,
                         )
                         return {
-                          label: corpus?.organisation?.display_name,
+                          label: corpus?.display_name,
                           value: id,
                         }
                       })}

--- a/src/hooks/useOrganisations.ts
+++ b/src/hooks/useOrganisations.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import { getOrganisations } from '@/api/Organisations'
+import { IError } from '@/interfaces'
+import { IOrganisation } from '@/interfaces/Organisation'
+
+const useOrganisations = () => {
+  const [organisations, setOrganisations] = useState<IOrganisation[]>([])
+  const [error, setError] = useState<IError | null | undefined>()
+  const [loading, setLoading] = useState<boolean>(false)
+
+  const handleGetOrganisations = useCallback(() => {
+    setLoading(true)
+    setError(null)
+
+    getOrganisations()
+      .then(({ response }) => {
+        setOrganisations(response)
+      })
+      .catch((error: IError) => {
+        setError(error)
+      })
+      .finally(() => {
+        setLoading(false)
+      })
+  }, [])
+
+  const reload = () => {
+    handleGetOrganisations()
+  }
+
+  useEffect(() => {
+    setLoading(true)
+    handleGetOrganisations()
+  }, [handleGetOrganisations])
+
+  return { organisations, error, loading, reload }
+}
+
+export default useOrganisations

--- a/src/interfaces/Organisation.ts
+++ b/src/interfaces/Organisation.ts
@@ -1,0 +1,7 @@
+export interface IOrganisation {
+  id: number
+  internal_name: string
+  display_name: string
+  description: string
+  type: string
+}

--- a/src/tests/components/forms/CorpusForm.test.tsx
+++ b/src/tests/components/forms/CorpusForm.test.tsx
@@ -9,6 +9,8 @@ import { BrowserRouter } from 'react-router-dom'
 import { ChakraProvider } from '@chakra-ui/react'
 import '../../setup'
 import { ICorpusType } from '@/interfaces/CorpusType'
+import useOrganisations from '@/hooks/useOrganisations'
+import { IOrganisation } from '@/interfaces/Organisation'
 
 // Mock the API calls
 vi.mock('@/api/Corpora', () => ({
@@ -21,6 +23,10 @@ vi.mock('@/hooks/useConfig', () => ({
 }))
 
 vi.mock('@/hooks/useCorpusTypes', () => ({
+  default: vi.fn(),
+}))
+
+vi.mock('@/hooks/useOrganisations', () => ({
   default: vi.fn(),
 }))
 
@@ -59,6 +65,23 @@ const mockConfig = {
   ],
 }
 
+const mockOrganisations: IOrganisation[] = [
+  {
+    id: 1,
+    internal_name: 'TEST',
+    display_name: 'Test Organisation 1',
+    description: "Test Organisation 1's description",
+    type: 'Test',
+  },
+  {
+    id: 2,
+    internal_name: 'CCLW',
+    display_name: 'Test Organisation 2',
+    description: "Test Organisation 2's description",
+    type: 'Academic',
+  },
+]
+
 const mockCorpusTypes: ICorpusType[] = [
   {
     name: 'Test Corpus Type 1',
@@ -72,6 +95,9 @@ const mockCorpusTypes: ICorpusType[] = [
 
 const mockUseConfig = useConfig as unknown as ReturnType<typeof vi.fn>
 const mockUseCorpusTypes = useCorpusTypes as unknown as ReturnType<typeof vi.fn>
+const mockUseOrganisations = useOrganisations as unknown as ReturnType<
+  typeof vi.fn
+>
 
 describe('CorpusForm', () => {
   beforeEach(() => {
@@ -83,6 +109,11 @@ describe('CorpusForm', () => {
     })
     mockUseCorpusTypes.mockReturnValue({
       corpusTypes: mockCorpusTypes,
+      loading: false,
+      error: null,
+    })
+    mockUseOrganisations.mockReturnValue({
+      organisations: mockOrganisations,
       loading: false,
       error: null,
     })


### PR DESCRIPTION
# What's changed

Update corpus form in admin service to use new /all organisations API route so we always have the latest organisations.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
