### PR TITLE
Enable running tests against mock and local API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,3 @@
 VITE_API_URL=http://localhost:8888/api/
+
+SECRET_KEY=secret_test_key

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@typescript-eslint/eslint-plugin": "^7.1.1",
     "@typescript-eslint/parser": "^7.18.0",
     "@vitejs/plugin-react": "^4.3.1",
+    "dotenv": "^16.4.7",
     "eslint": "^8.44.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview",
     "prod": "tsc && vite build && vite preview --port 3000 --host",
     "test": "vitest",
+    "test-int": "DISABLE_MSW=true vitest",
     "type-check": "tsc"
   },
   "dependencies": {

--- a/src/interfaces/Family.ts
+++ b/src/interfaces/Family.ts
@@ -94,23 +94,23 @@ export interface ILawsAndPoliciesFamily extends IFamilyBase {
   metadata: ILawsAndPoliciesMetadata
 }
 
-interface IAfProjectsFamily extends IFamilyBase {
+export interface IAfProjectsFamily extends IFamilyBase {
   metadata: IAfProjectsMetadata
 }
 
-interface ICifProjectsFamily extends IFamilyBase {
+export interface ICifProjectsFamily extends IFamilyBase {
   metadata: ICifProjectsMetadata
 }
 
-interface IGefProjectsFamily extends IFamilyBase {
+export interface IGefProjectsFamily extends IFamilyBase {
   metadata: IGefProjectsMetadata
 }
 
-interface IGcfProjectsFamily extends IFamilyBase {
+export interface IGcfProjectsFamily extends IFamilyBase {
   metadata: IGcfProjectsMetadata
 }
 
-interface IReportsFamily extends IFamilyBase {
+export interface IReportsFamily extends IFamilyBase {
   metadata: IReportsMetadata
 }
 

--- a/src/tests/components/lists/FamilyList.test.tsx
+++ b/src/tests/components/lists/FamilyList.test.tsx
@@ -24,23 +24,23 @@ describe('FamilyList', () => {
     customRender(<FamilyList />)
     // Verify expected family properties are rendered there
     expect(await screen.findAllByText(UNFCCCFamily.title)).toHaveLength(1)
-    expect(screen.getAllByText(UNFCCCFamily.category)).toHaveLength(2)
-    expect(screen.getAllByText(UNFCCCFamily.geography)).toHaveLength(2)
+    expect(screen.getAllByText(UNFCCCFamily.category)).toHaveLength(3)
+    expect(screen.getAllByText(UNFCCCFamily.geography)).toHaveLength(3)
 
     // We put the formatDate here so that the formatting runs in the same locale
     // as the component when it runs formatDate.
     expect(
       screen.getAllByText(formatDate(UNFCCCFamily.published_date)),
-    ).toHaveLength(1)
+    ).toHaveLength(2)
     expect(
       screen.getAllByText(formatDate(UNFCCCFamily.last_updated_date)),
-    ).toHaveLength(1)
+    ).toHaveLength(2)
     expect(screen.getAllByText(formatDate(UNFCCCFamily.created))).toHaveLength(
-      1,
+      2,
     )
     expect(
       screen.getAllByText(formatDate(UNFCCCFamily.last_modified)),
-    ).toHaveLength(1)
+    ).toHaveLength(2)
   })
 
   it('sorts families by title when title header is clicked', async () => {

--- a/src/tests/helpers.ts
+++ b/src/tests/helpers.ts
@@ -1,3 +1,4 @@
+import { jwtDecode } from 'jwt-decode'
 import sign from 'jwt-encode'
 
 interface SetupUserParams {
@@ -31,4 +32,11 @@ export const setupUser = ({
       process.env.SECRET_KEY as string,
     ),
   )
+}
+
+export const extractOrgFromAuthHeader = (headers: Headers) => {
+  const authHeader = headers.get('authorization')
+  const parsedAuthToken: Record<string, object> = jwtDecode(authHeader || '')
+  const authorisation = parsedAuthToken?.authorisation || {}
+  return Object.keys(authorisation)[0]
 }

--- a/src/tests/helpers.ts
+++ b/src/tests/helpers.ts
@@ -29,7 +29,7 @@ export const setupUser = ({
         },
         org_id: orgId,
       },
-      process.env.SECRET_KEY as string,
+      process.env.SECRET_KEY || '',
     ),
   )
 }

--- a/src/tests/helpers.ts
+++ b/src/tests/helpers.ts
@@ -28,7 +28,7 @@ export const setupUser = ({
         },
         org_id: orgId,
       },
-      'secret_test_key',
+      process.env.SECRET_KEY as string,
     ),
   )
 }

--- a/src/tests/helpers.ts
+++ b/src/tests/helpers.ts
@@ -1,12 +1,20 @@
 import sign from 'jwt-encode'
 
-export const setupUser = (
-  organisationName: string = 'CPR',
-  email: string = 'test@climatepolicyradar.com',
-  isSuperuser: boolean = true,
-  isAdmin: boolean = true,
-  orgId: number = 1,
-) => {
+interface SetupUserParams {
+  organisationName?: string
+  email?: string
+  isSuperuser?: boolean
+  isAdmin?: boolean
+  orgId?: number
+}
+
+export const setupUser = ({
+  organisationName = 'CCLW',
+  email = 'user@navigator.com',
+  isSuperuser = true,
+  isAdmin = true,
+  orgId = 1,
+}: SetupUserParams = {}) => {
   localStorage.setItem(
     'token',
     sign(
@@ -17,10 +25,10 @@ export const setupUser = (
           [organisationName]: {
             is_admin: isAdmin,
           },
-          org_id: orgId,
         },
+        org_id: orgId,
       },
-      '',
+      'secret_test_key',
     ),
   )
 }

--- a/src/tests/mocks/api/configHandlers.ts
+++ b/src/tests/mocks/api/configHandlers.ts
@@ -1,13 +1,10 @@
 import { cclwConfigMock, mcfConfigMock } from '@/tests/utilsTest/mocks'
 import { http, HttpResponse } from 'msw'
-import { jwtDecode } from 'jwt-decode'
+import { extractOrgFromAuthHeader } from '@/tests/helpers'
 
 export const configHandlers = [
   http.get('*/v1/config', ({ request }) => {
-    const authHeader = request.headers.get('authorization')
-    const parsedAuthToken: Record<string, object> = jwtDecode(authHeader || '')
-    const authorisation = parsedAuthToken?.authorisation || {}
-    const org = Object.keys(authorisation)[0]
+    const org = extractOrgFromAuthHeader(request.headers)
     if (org && ['GCF', 'GEF', 'AF', 'CIF'].includes(org)) {
       return HttpResponse.json({ ...mcfConfigMock })
     }

--- a/src/tests/mocks/api/configHandlers.ts
+++ b/src/tests/mocks/api/configHandlers.ts
@@ -3,8 +3,8 @@ import { http, HttpResponse } from 'msw'
 import { jwtDecode } from 'jwt-decode'
 
 export const configHandlers = [
-  http.get('*/v1/config', (req) => {
-    const authHeader = req.request.headers.get('authorization')
+  http.get('*/v1/config', ({ request }) => {
+    const authHeader = request.headers.get('authorization')
     const parsedAuthToken: Record<string, object> = jwtDecode(authHeader || '')
     const authorisation = parsedAuthToken?.authorisation || {}
     const org = Object.keys(authorisation)[0]

--- a/src/tests/mocks/api/familyHandlers.ts
+++ b/src/tests/mocks/api/familyHandlers.ts
@@ -1,10 +1,12 @@
+import { TFamilyFormPost } from '@/interfaces'
 import {
   mockCCLWFamilyOneDocument,
   mockCCLWFamilyWithOneEvent,
   mockFamiliesData,
-  mockGCFFamily,
 } from '@/tests/utilsTest/mocks'
 import { http, HttpResponse } from 'msw'
+import { createFamily, getFamily } from '../repository'
+import { extractOrgFromAuthHeader } from '@/tests/helpers'
 
 export const familyHandlers = [
   http.get('*/v1/families/:id', ({ params }) => {
@@ -16,15 +18,20 @@ export const familyHandlers = [
       return HttpResponse.json({ ...mockCCLWFamilyOneDocument })
     }
     if (id?.includes('GCF')) {
-      return HttpResponse.json({ ...mockGCFFamily })
+      const { id } = params
+      const family = getFamily(id as string)
+      return HttpResponse.json(family)
     }
     return HttpResponse.json({ ...mockFamiliesData[0] })
   }),
   http.get('*/v1/families/', () => {
     return HttpResponse.json({ families: { data: mockFamiliesData } })
   }),
-  http.post('*/v1/families', () => {
-    return HttpResponse.json('GCF.family.i00000004.n0000')
+  http.post('*/v1/families', async ({ request }) => {
+    const org = extractOrgFromAuthHeader(request.headers)
+    const updateData = await request.json()
+    const createdFamilyId = createFamily(updateData as TFamilyFormPost, org)
+    return HttpResponse.json(createdFamilyId)
   }),
   http.get('*/v1/family/:id/edit', ({ params }) => {
     const { id } = params

--- a/src/tests/mocks/api/familyHandlers.ts
+++ b/src/tests/mocks/api/familyHandlers.ts
@@ -3,6 +3,7 @@ import {
   mockCCLWFamilyOneDocument,
   mockCCLWFamilyWithOneEvent,
   mockFamiliesData,
+  mockUNFCCCFamily,
 } from '@/tests/utilsTest/mocks'
 import { http, HttpResponse } from 'msw'
 import { createFamily, getFamily } from '../repository'
@@ -22,7 +23,7 @@ export const familyHandlers = [
       const family = getFamily(id as string)
       return HttpResponse.json(family)
     }
-    return HttpResponse.json({ ...mockFamiliesData[0] })
+    return HttpResponse.json({ ...mockUNFCCCFamily })
   }),
   http.get('*/v1/families/', () => {
     return HttpResponse.json({ families: { data: mockFamiliesData } })

--- a/src/tests/mocks/api/familyHandlers.ts
+++ b/src/tests/mocks/api/familyHandlers.ts
@@ -2,6 +2,7 @@ import {
   mockCCLWFamilyOneDocument,
   mockCCLWFamilyWithOneEvent,
   mockFamiliesData,
+  mockGCFFamily,
 } from '@/tests/utilsTest/mocks'
 import { http, HttpResponse } from 'msw'
 
@@ -14,10 +15,16 @@ export const familyHandlers = [
     if (id === 'mockCCLWFamilyOneDocument') {
       return HttpResponse.json({ ...mockCCLWFamilyOneDocument })
     }
+    if (id?.includes('GCF')) {
+      return HttpResponse.json({ ...mockGCFFamily })
+    }
     return HttpResponse.json({ ...mockFamiliesData[0] })
   }),
   http.get('*/v1/families/', () => {
     return HttpResponse.json({ families: { data: mockFamiliesData } })
+  }),
+  http.post('*/v1/families', () => {
+    return HttpResponse.json('GCF.family.i00000004.n0000')
   }),
   http.get('*/v1/family/:id/edit', ({ params }) => {
     const { id } = params

--- a/src/tests/mocks/api/familyHandlers.ts
+++ b/src/tests/mocks/api/familyHandlers.ts
@@ -19,7 +19,6 @@ export const familyHandlers = [
       return HttpResponse.json({ ...mockCCLWFamilyOneDocument })
     }
     if (id?.includes('GCF')) {
-      const { id } = params
       const family = getFamily(id as string)
       return HttpResponse.json(family)
     }

--- a/src/tests/mocks/repository.ts
+++ b/src/tests/mocks/repository.ts
@@ -1,10 +1,22 @@
 import { IEvent } from '@/interfaces/Event'
-import { mockCollection, mockDocument2, mockEvent } from '../utilsTest/mocks'
-import { ICollection, ICollectionFormPost, IDocument } from '@/interfaces'
+import {
+  mockCollection,
+  mockDocument2,
+  mockEvent,
+  mockFamiliesData,
+} from '../utilsTest/mocks'
+import {
+  ICollection,
+  ICollectionFormPost,
+  IDocument,
+  TFamily,
+  TFamilyFormPost,
+} from '@/interfaces'
 
 let eventRepository = [mockEvent]
 let documentRepository = [mockDocument2]
 let collectionRepository = [mockCollection]
+const familyRepository: TFamily[] = [...mockFamiliesData]
 
 const getEvent = (id: string) => {
   return eventRepository.find((event) => event.import_id === id)
@@ -57,6 +69,19 @@ const updateCollection = (data: ICollection, id: string) => {
   })
 }
 
+const getFamily = (id: string) => {
+  return familyRepository.find((fam) => fam.import_id === id)
+}
+
+const createFamily = (data: TFamilyFormPost, org: string) => {
+  const import_id = `${org}.family.${familyRepository.length}`
+  familyRepository.push({
+    import_id: import_id,
+    ...data,
+  } as TFamily)
+  return import_id
+}
+
 const reset = () => {
   eventRepository = [mockEvent]
   documentRepository = [mockDocument2]
@@ -71,5 +96,7 @@ export {
   getCollection,
   createCollection,
   updateCollection,
+  getFamily,
+  createFamily,
   reset,
 }

--- a/src/tests/setup.js
+++ b/src/tests/setup.js
@@ -59,20 +59,26 @@ window.IntersectionObserver =
 
 // Establish API mocking before all tests.
 beforeAll(() => {
-  server.listen()
+  if (!process.env.DISABLE_MSW) {
+    server.listen()
+  }
   setupUser()
 })
 
 // Reset any request handlers that we may add during the tests,
 // so they don't affect other tests.
 afterEach(() => {
-  server.resetHandlers()
+  if (!process.env.DISABLE_MSW) {
+    server.resetHandlers()
+  }
   cleanup()
   reset()
 })
 
 // Clean up after the tests are finished.
 afterAll(() => {
-  server.close()
+  if (!process.env.DISABLE_MSW) {
+    server.close()
+  }
   localStorage.clear()
 })

--- a/src/tests/setup.js
+++ b/src/tests/setup.js
@@ -4,6 +4,7 @@ import { server } from './mocks/server.ts'
 import * as matchers from '@testing-library/jest-dom/matchers'
 import { vi } from 'vitest'
 import { setupUser } from './helpers.ts'
+require('dotenv').config({ path: '.env' })
 
 expect.extend(matchers)
 

--- a/src/tests/utilsTest/mocks.tsx
+++ b/src/tests/utilsTest/mocks.tsx
@@ -441,7 +441,7 @@ const mockMCFConfig: IConfig = {
         author_type: {
           allow_any: false,
           allow_blanks: false,
-          allowed_values: ['Type One', 'Type Two'],
+          allowed_values: ['Individual', 'Academic/Research'],
         },
         external_id: {
           allow_any: true,

--- a/src/tests/utilsTest/mocks.tsx
+++ b/src/tests/utilsTest/mocks.tsx
@@ -502,12 +502,12 @@ const mockMCFConfig: IConfig = {
 
 // Exports
 export const mockFamiliesData = [
-  mockGCFFamily,
   mockUNFCCCFamily,
   mockCCLWFamily,
   mockUNFCCCFamilyNoDocumentsNoEvents,
   mockCCLWFamilyNoDocuments,
   mockCCLWFamilyNoEvents,
+  mockGCFFamily,
 ]
 export { mockConfig as configMock }
 export { mockCCLWConfig as cclwConfigMock }
@@ -520,3 +520,5 @@ export { mockCCLWFamilyWithOneEvent }
 export { mockCCLWFamilyOneDocument }
 export { mockGCFFamily }
 export { mockCollection }
+export { mockUNFCCCFamily }
+export { mockCCLWFamily }

--- a/src/tests/utilsTest/mocks.tsx
+++ b/src/tests/utilsTest/mocks.tsx
@@ -2,6 +2,7 @@ import { ICollection, IConfig, IDocument, IEvent } from '@/interfaces'
 import {
   ILawsAndPoliciesFamily,
   IInternationalAgreementsFamily,
+  IReportsFamily,
 } from '@/interfaces/Family'
 
 const mockConfig = {
@@ -160,6 +161,33 @@ const mockCCLWFamilyOneDocument: ILawsAndPoliciesFamily = {
   documents: ['document5'],
   created: new Date(2021, 1, 5).toISOString(),
   last_modified: new Date(2021, 1, 6).toISOString(),
+}
+
+const mockGCFFamily: IReportsFamily = {
+  import_id: 'GCF.family.1.0',
+  title: 'GCF Family',
+  summary: 'Summary for GCF Family One',
+  geography: 'Geography One',
+  geographies: ['Geography One'],
+  category: 'Category One',
+  status: 'active',
+  slug: 'gcf-family-one',
+  events: ['event1', 'event2'],
+  published_date: new Date(2021, 3, 1).toISOString(),
+  last_updated_date: new Date(2021, 0, 2).toISOString(),
+  documents: [],
+  collections: ['collection1', 'collection2'],
+  organisation: 'GCF',
+  corpus_import_id: 'GCF.corpus.Guidance.n0000',
+  corpus_title: 'GCF Guidance',
+  corpus_type: 'Reports',
+  created: new Date(2021, 0, 3).toISOString(),
+  last_modified: new Date(2021, 0, 4).toISOString(),
+  metadata: {
+    author: ['Author One', 'Author 2'],
+    author_type: ['Individual', 'Academic/Research'],
+    external_id: ['1234'],
+  },
 }
 
 const mockEvent: IEvent = {
@@ -474,6 +502,7 @@ const mockMCFConfig: IConfig = {
 
 // Exports
 export const mockFamiliesData = [
+  mockGCFFamily,
   mockUNFCCCFamily,
   mockCCLWFamily,
   mockUNFCCCFamilyNoDocumentsNoEvents,
@@ -489,4 +518,5 @@ export { mockDocument2 }
 export { mockEvent }
 export { mockCCLWFamilyWithOneEvent }
 export { mockCCLWFamilyOneDocument }
+export { mockGCFFamily }
 export { mockCollection }

--- a/src/tests/views/FamilyCreate.test.tsx
+++ b/src/tests/views/FamilyCreate.test.tsx
@@ -74,7 +74,7 @@ describe('FamilyForm create', () => {
     await user.click(screen.getByRole('button', { name: 'Create Family' }))
 
     expect(
-      screen.getByText('Family has been successfully created'),
+      await screen.findByText('Family has been successfully created'),
     ).toBeInTheDocument()
     expect(
       await screen.findByRole('heading', {

--- a/src/tests/views/FamilyCreate.test.tsx
+++ b/src/tests/views/FamilyCreate.test.tsx
@@ -4,7 +4,7 @@ import { setupUser } from '../helpers.ts'
 
 describe('FamilyForm create', () => {
   it('allows selection of multiple authors for Reports', async () => {
-    setupUser('GCF')
+    setupUser({ organisationName: 'GCF', orgId: 6 })
     const { user } = renderRoute('/family/new')
 
     expect(
@@ -54,17 +54,17 @@ describe('FamilyForm create', () => {
     await user.click(author_type_dropdown)
     await user.click(
       screen.getByRole('option', {
-        name: 'Type One',
+        name: 'Individual',
       }),
     )
     await user.click(author_type_dropdown)
     await user.click(
       screen.getByRole('option', {
-        name: 'Type Two',
+        name: 'Academic/Research',
       }),
     )
 
-    expect(screen.getByText('Type One')).toBeInTheDocument()
-    expect(screen.getByText('Type Two')).toBeInTheDocument()
+    expect(screen.getByText('Individual')).toBeInTheDocument()
+    expect(screen.getByText('Academic/Research')).toBeInTheDocument()
   })
 })

--- a/src/tests/views/FamilyCreate.test.tsx
+++ b/src/tests/views/FamilyCreate.test.tsx
@@ -13,26 +13,30 @@ describe('FamilyForm create', () => {
 
     await user.type(
       await screen.findByRole('textbox', { name: 'Title' }),
-      'Test family',
+      'GCF Family',
     )
+    await user.click(screen.getByRole('combobox', { name: 'Geographies' }))
+    const geo_option = screen.getByRole('option', {
+      name: 'Afghanistan',
+    })
+    await user.click(geo_option)
 
+    const corpus_name = 'Climate Investment Funds Guidance'
     await user.click(screen.getByRole('combobox', { name: 'Corpus' }))
-
     const corpus_option = screen.getByRole('option', {
-      name: 'Climate Investment Funds Guidance',
+      name: corpus_name,
     })
     await user.click(corpus_option)
+    expect(screen.getByText(corpus_name)).toBeInTheDocument()
 
-    expect(
-      screen.getByText('Climate Investment Funds Guidance'),
-    ).toBeInTheDocument()
+    await user.click(screen.getByRole('radio', { name: 'Reports (Guidance)' }))
 
     expect(await screen.findByText('Metadata')).toBeInTheDocument()
-
     expect(screen.queryByLabelText('Project Id')).not.toBeInTheDocument()
     expect(
       screen.queryByLabelText('Implementing Agency'),
     ).not.toBeInTheDocument()
+
     expect(
       await screen.findByRole('textbox', { name: 'External Id' }),
     ).toBeInTheDocument()
@@ -66,5 +70,17 @@ describe('FamilyForm create', () => {
 
     expect(screen.getByText('Individual')).toBeInTheDocument()
     expect(screen.getByText('Academic/Research')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Create Family' }))
+
+    expect(
+      screen.getByText('Family has been successfully created'),
+    ).toBeInTheDocument()
+    expect(
+      await screen.findByRole('heading', {
+        level: 1,
+        name: 'Editing: GCF Family',
+      }),
+    ).toBeInTheDocument()
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1984,6 +1984,11 @@ dom-helpers@^5.0.1:
     "@babel/runtime" "^7.8.7"
     csstype "^3.0.2"
 
+dotenv@^16.4.7:
+  version "16.4.7"
+  resolved "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz"
+  integrity sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==
+
 draft-js@^0.11.7:
   version "0.11.7"
   resolved "https://registry.npmjs.org/draft-js/-/draft-js-0.11.7.tgz"
@@ -2796,7 +2801,7 @@ iconv-lite@0.6.3:
 
 ignore@^5.2.0, ignore@^5.2.4:
   version "5.3.2"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
+  resolved "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz"
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
 
 ignore@~6.0.2:


### PR DESCRIPTION
# What's changed
- extend the FamilyCreate.test.tsx to submit the form
- add an npm script to run tests without mock service worker (so that they run against a real API and not mocked API)


## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
