### PR TITLE
Feature/app 55 read corpus type information via admin service UI

### DIFF
--- a/src/api/CorpusTypes.ts
+++ b/src/api/CorpusTypes.ts
@@ -1,8 +1,8 @@
 import { AxiosError } from 'axios'
 
 import API from '@/api'
-import { IError } from '@/interfaces'
 import { setToken } from '@/api/Auth'
+import { IError } from '@/interfaces'
 import { ICorpusType } from '@/interfaces/CorpusType'
 
 export async function getCorpusTypes() {
@@ -17,7 +17,7 @@ export async function getCorpusTypes() {
         status: error.response?.status || 500,
         detail: error.response?.data?.detail || 'Unknown error',
         message: error.message,
-        returnPage: '/corpora',
+        returnPage: '/corpus-types',
       }
       throw e
     })

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -122,6 +122,17 @@ export function SideMenu() {
                     </IconLink>
                   </>
                 )}
+                {isSuperUser && (
+                  <>
+                    <IconLink
+                      icon={<Icon as={GoLog} mr='2' />}
+                      to='/corpus-types'
+                      current={isCurrentPage('corpus-types')}
+                    >
+                      Corpus Types
+                    </IconLink>
+                  </>
+                )}
                 <IconLink icon={<Icon as={GoClock} mr='2' />}>
                   View audit history
                 </IconLink>

--- a/src/components/forms/CorpusTypeForm.tsx
+++ b/src/components/forms/CorpusTypeForm.tsx
@@ -1,0 +1,205 @@
+import { useEffect, useRef, useState, useCallback } from 'react'
+import { useForm, SubmitHandler, SubmitErrorHandler } from 'react-hook-form'
+import { yupResolver } from '@hookform/resolvers/yup'
+import { IError } from '@/interfaces'
+import { corpusTypeSchema } from '@/schemas/corpusTypeSchema'
+import {
+  FormControl,
+  FormLabel,
+  Textarea,
+  VStack,
+  Button,
+  ButtonGroup,
+  useToast,
+  Tooltip,
+  Icon,
+  ModalOverlay,
+  ModalHeader,
+  ModalCloseButton,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  Modal,
+} from '@chakra-ui/react'
+import { ApiError } from '../feedback/ApiError'
+import { InfoOutlineIcon } from '@chakra-ui/icons'
+import { TextField } from './fields/TextField'
+import * as Yup from 'yup'
+import { ICorpusType } from '@/interfaces/CorpusType'
+
+type TProps = {
+  corpusType?: ICorpusType
+}
+
+export type ICorpusTypeFormSubmit = Yup.InferType<typeof corpusTypeSchema>
+
+export const CorpusTypeForm = ({ corpusType: loadedCorpusType }: TProps) => {
+  const toast = useToast()
+  const [formError, setFormError] = useState<IError | null | undefined>()
+  const {
+    register,
+    handleSubmit,
+    control,
+    reset,
+    formState: { isSubmitting },
+    getValues,
+  } = useForm<ICorpusTypeFormSubmit>({
+    resolver: yupResolver(corpusTypeSchema),
+  })
+
+  const initialDescription = useRef<string | undefined>(
+    loadedCorpusType?.description,
+  )
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  const [isConfirmed, setIsConfirmed] = useState(false)
+
+  const handleFormSubmission = useCallback(
+    // TODO: Remove under APP-54.
+    /* trunk-ignore(eslint/@typescript-eslint/require-await) */
+    async (formValues: ICorpusTypeFormSubmit) => {
+      setFormError(null)
+
+      // Only check for corpus type description changes if updating an existing corpus
+      if (
+        loadedCorpusType &&
+        formValues.description !== initialDescription.current &&
+        !isConfirmed
+      ) {
+        setIsModalOpen(true)
+        return
+      }
+
+      if (loadedCorpusType) {
+        toast({
+          title: 'Not implemented',
+          description: 'Corpus type update has not been implemented',
+          status: 'error',
+          position: 'top',
+        })
+      } else {
+        toast({
+          title: 'Not implemented',
+          description: 'Corpus type update has not been implemented',
+          status: 'error',
+          position: 'top',
+        })
+      }
+    },
+    [loadedCorpusType, isConfirmed, initialDescription, toast, setFormError],
+  )
+
+  const onSubmit: SubmitHandler<ICorpusTypeFormSubmit> = useCallback(
+    (data) => {
+      handleFormSubmission(data).catch((error: IError) => {
+        console.error(error)
+      })
+    },
+    [handleFormSubmission],
+  )
+
+  const onSubmitErrorHandler: SubmitErrorHandler<ICorpusTypeFormSubmit> =
+    useCallback((errors) => {
+      console.error(errors)
+    }, [])
+
+  const handleModalConfirm = () => {
+    setIsConfirmed(true)
+    setIsModalOpen(false)
+  }
+
+  const handleModalCancel = () => {
+    setIsModalOpen(false)
+  }
+
+  const handleFormSubmissionWithConfirmation = useCallback(() => {
+    if (isConfirmed) {
+      void handleSubmit(onSubmit, onSubmitErrorHandler)().catch((error) => {
+        console.error('Form submission error:', error)
+      })
+    }
+  }, [isConfirmed, handleSubmit, onSubmit, onSubmitErrorHandler])
+
+  useEffect(() => {
+    handleFormSubmissionWithConfirmation()
+  }, [handleFormSubmissionWithConfirmation])
+
+  useEffect(() => {
+    if (loadedCorpusType) {
+      reset({
+        name: loadedCorpusType?.name || '',
+        description: loadedCorpusType?.description || '',
+      })
+    }
+  }, [loadedCorpusType, reset])
+
+  return (
+    <>
+      <form onSubmit={handleSubmit(onSubmit, onSubmitErrorHandler)}>
+        <VStack gap='4' mb={12} align={'stretch'}>
+          {formError && <ApiError error={formError} />}
+
+          <TextField
+            name='name'
+            label='Title'
+            control={control}
+            isRequired={true}
+          />
+
+          <FormControl isRequired>
+            <FormLabel>
+              Description
+              <Tooltip label='Updating this will also apply this change to all other corpora of this type'>
+                <Icon as={InfoOutlineIcon} ml={2} cursor='pointer' />
+              </Tooltip>
+            </FormLabel>
+            <Textarea
+              height={'100px'}
+              bg='white'
+              {...register('description')}
+            />
+          </FormControl>
+
+          <Modal isOpen={isModalOpen} onClose={handleModalCancel}>
+            <ModalOverlay />
+            <ModalContent>
+              <ModalHeader>Confirm Update</ModalHeader>
+              <ModalCloseButton />
+              <ModalBody data-testid='modal-body'>
+                <p>
+                  You have changed the corpus type description of{' '}
+                  <strong>{getValues('name') || 'unknown'}</strong>.
+                </p>
+                <br></br>
+                <p>
+                  This will update all corpora with the type{' '}
+                  <strong>{getValues('name') || 'unknown'}</strong> with the
+                  description{' '}
+                  <em style={{ color: 'blue' }}>
+                    {getValues('description') || 'unknown'}
+                  </em>
+                  .
+                </p>
+                <br></br>
+                Do you wish to proceed?
+              </ModalBody>
+              <ModalFooter>
+                <Button colorScheme='blue' mr={3} onClick={handleModalConfirm}>
+                  Confirm
+                </Button>
+                <Button variant='ghost' onClick={handleModalCancel}>
+                  Cancel
+                </Button>
+              </ModalFooter>
+            </ModalContent>
+          </Modal>
+
+          <ButtonGroup>
+            <Button type='submit' colorScheme='blue' disabled={isSubmitting}>
+              {(loadedCorpusType ? 'Update ' : 'Create new ') + 'Corpus type'}
+            </Button>
+          </ButtonGroup>
+        </VStack>
+      </form>
+    </>
+  )
+}

--- a/src/components/lists/CorpusTypeList.tsx
+++ b/src/components/lists/CorpusTypeList.tsx
@@ -60,7 +60,7 @@ export default function CorpusTypeList() {
         .sort(sortBy(sortControls.key, sortControls.reverse))
       setFilteredItems(sortedItems)
     } else {
-      setFilteredItems([]) // Set to empty array if corpusTypes is undefined
+      setFilteredItems([])
     }
   }, [sortControls, corpusTypes])
 

--- a/src/components/lists/CorpusTypeList.tsx
+++ b/src/components/lists/CorpusTypeList.tsx
@@ -54,10 +54,14 @@ export default function CorpusTypeList() {
   }
 
   useEffect(() => {
-    const sortedItems = corpusTypes
-      .slice()
-      .sort(sortBy(sortControls.key, sortControls.reverse))
-    setFilteredItems(sortedItems)
+    if (corpusTypes) {
+      const sortedItems = corpusTypes
+        .slice()
+        .sort(sortBy(sortControls.key, sortControls.reverse))
+      setFilteredItems(sortedItems)
+    } else {
+      setFilteredItems([]) // Set to empty array if corpusTypes is undefined
+    }
   }, [sortControls, corpusTypes])
 
   useEffect(() => {

--- a/src/components/lists/CorpusTypeList.tsx
+++ b/src/components/lists/CorpusTypeList.tsx
@@ -1,0 +1,142 @@
+import { useState, useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import { IError } from '@/interfaces'
+import {
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  TableContainer,
+  IconButton,
+  Box,
+  HStack,
+  Tooltip,
+  SkeletonText,
+} from '@chakra-ui/react'
+import { GoPencil } from 'react-icons/go'
+
+import { Loader } from '../Loader'
+import { sortBy } from '@/utils/sortBy'
+import { ArrowDownIcon, ArrowUpIcon, ArrowUpDownIcon } from '@chakra-ui/icons'
+import { ApiError } from '../feedback/ApiError'
+import { ICorpusType } from '@/interfaces/CorpusType'
+import useCorpusTypes from '@/hooks/useCorpusTypes'
+
+export default function CorpusTypeList() {
+  const [sortControls, setSortControls] = useState<{
+    key: keyof ICorpusType
+    reverse: boolean
+  }>({ key: 'name', reverse: false })
+  const [filteredItems, setFilteredItems] = useState<ICorpusType[]>()
+  const { corpusTypes, loading, error } = useCorpusTypes()
+  const [corpusError] = useState<string | null | undefined>()
+  const [formError] = useState<IError | null | undefined>()
+
+  const renderSortIcon = (key: keyof ICorpusType) => {
+    if (sortControls.key !== key) {
+      return <ArrowUpDownIcon />
+    }
+    if (sortControls.reverse) {
+      return <ArrowDownIcon />
+    } else {
+      return <ArrowUpIcon />
+    }
+  }
+
+  const handleHeaderClick = (key: keyof ICorpusType) => {
+    if (sortControls.key === key) {
+      setSortControls({ key, reverse: !sortControls.reverse })
+    } else {
+      setSortControls({ key, reverse: false })
+    }
+  }
+
+  useEffect(() => {
+    const sortedItems = corpusTypes
+      .slice()
+      .sort(sortBy(sortControls.key, sortControls.reverse))
+    setFilteredItems(sortedItems)
+  }, [sortControls, corpusTypes])
+
+  useEffect(() => {
+    setFilteredItems(corpusTypes)
+  }, [corpusTypes])
+
+  return (
+    <>
+      {loading && (
+        <Box padding='4' bg='white'>
+          <Loader />
+          <SkeletonText mt='4' noOfLines={3} spacing='4' skeletonHeight='2' />
+        </Box>
+      )}
+      {!loading && (
+        <Box flex={1}>
+          <Box>
+            {error && <ApiError error={error} />}
+            {formError && <ApiError error={formError} />}
+          </Box>
+          <TableContainer height={'100%'} whiteSpace={'normal'}>
+            <Table size='sm' variant={'striped'}>
+              <Thead>
+                <Tr>
+                  <Th
+                    onClick={() => handleHeaderClick('name')}
+                    cursor='pointer'
+                  >
+                    Name {renderSortIcon('name')}
+                  </Th>
+                  <Th
+                    onClick={() => handleHeaderClick('description')}
+                    cursor='pointer'
+                  >
+                    Description {renderSortIcon('description')}
+                  </Th>
+                  <Th></Th>
+                </Tr>
+              </Thead>
+              <Tbody>
+                {filteredItems?.length === 0 && (
+                  <Tr>
+                    <Td colSpan={4}>
+                      No results found, please amend your search
+                    </Td>
+                  </Tr>
+                )}
+                {filteredItems?.map((corpus) => (
+                  <Tr
+                    key={corpus.name}
+                    borderLeft={corpus.name === corpusError ? '2px' : 'inherit'}
+                    borderColor={
+                      corpus.name === corpusError ? 'red.500' : 'inherit'
+                    }
+                  >
+                    <Td>{corpus.name}</Td>
+                    <Td>{corpus.description}</Td>
+                    <Td>
+                      <HStack gap={2}>
+                        <Tooltip label='Edit'>
+                          <Link to={`/corpus-type/${corpus.name}/edit`}>
+                            <IconButton
+                              aria-label='Edit corpus type'
+                              icon={<GoPencil />}
+                              variant='outline'
+                              size='sm'
+                              colorScheme='blue'
+                            />
+                          </Link>
+                        </Tooltip>
+                      </HStack>
+                    </Td>
+                  </Tr>
+                ))}
+              </Tbody>
+            </Table>
+          </TableContainer>
+        </Box>
+      )}
+    </>
+  )
+}

--- a/src/hooks/useCorpusType.ts
+++ b/src/hooks/useCorpusType.ts
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import { getCorpusType } from '@/api/CorpusTypes'
+import { IError } from '@/interfaces'
+import { ICorpusType } from '@/interfaces/CorpusType'
+
+const useCorpusType = (id?: string) => {
+  const [corpusType, setCorpusType] = useState<ICorpusType>()
+  const [error, setError] = useState<IError>()
+  const [loading, setLoading] = useState<boolean>(false)
+
+  const handleGetCorpusType = useCallback(() => {
+    // Ignore is used to make sure that only the latest request's response
+    // updates the state & to prevent outdated responses from overwriting newer
+    // data, thus avoiding race conditions.
+    let ignore = false
+    if (id) {
+      setLoading(true)
+
+      getCorpusType(id)
+        .then(({ response }) => {
+          if (!ignore) setCorpusType(response.data)
+        })
+        .catch((error: IError) => {
+          setError(error)
+        })
+        .finally(() => {
+          setLoading(false)
+        })
+    }
+
+    return () => {
+      ignore = true
+    }
+  }, [id])
+
+  const reload = () => {
+    handleGetCorpusType()
+  }
+
+  useEffect(() => {
+    if (id) {
+      setLoading(true)
+      handleGetCorpusType()
+    }
+  }, [id, handleGetCorpusType])
+
+  return { corpusType, error, loading, reload }
+}
+
+export default useCorpusType

--- a/src/interfaces/CorpusType.ts
+++ b/src/interfaces/CorpusType.ts
@@ -1,4 +1,12 @@
+import { TTaxonomy } from './Config'
+
 export interface ICorpusType {
   name: string
   description: string
+}
+
+export interface ICorpusTypeWithMeta {
+  name: string
+  description: string
+  metadata?: TTaxonomy
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -11,8 +11,11 @@ import Document from '@/views/document/Document'
 import Corpus from '@/views/corpus/Corpus'
 import Corpora from '@/views/corpus/Corpora'
 import CorpusList from '@/components/lists/CorpusList'
+import CorpusTypeList from '@/components/lists/CorpusTypeList'
 import { familyRoutes } from './familyRoutes'
 import { collectionRoutes } from './collectionRoutes'
+import CorpusTypes from '@/views/corpusTypes/CorpusTypes'
+import CorpusType from '@/views/corpusTypes/CorpusType'
 
 const authenticatedRoutes = [
   {
@@ -69,6 +72,28 @@ const authenticatedRoutes = [
                   {
                     path: '',
                     element: <CorpusList />,
+                    errorElement: <ErrorPage />,
+                  },
+                ],
+              },
+              {
+                path: '/corpus-type/new',
+                element: <CorpusType />,
+                errorElement: <ErrorPage />,
+              },
+              {
+                path: 'corpus-type/:name/edit',
+                element: <CorpusType />,
+                errorElement: <ErrorPage />,
+              },
+              {
+                path: 'corpus-types',
+                element: <CorpusTypes />,
+                errorElement: <ErrorPage />,
+                children: [
+                  {
+                    path: '',
+                    element: <CorpusTypeList />,
                     errorElement: <ErrorPage />,
                   },
                 ],

--- a/src/schemas/corpusSchema.ts
+++ b/src/schemas/corpusSchema.ts
@@ -23,7 +23,6 @@ export const corpusSchema = yup
       then: (schema) => schema.required(),
       otherwise: (schema) => schema.notRequired(),
     }),
-    // .nullable(),
     import_id_part1: yup
       .object({
         label: yup.string().when('$isNewCorpus', {

--- a/src/schemas/corpusTypeSchema.ts
+++ b/src/schemas/corpusTypeSchema.ts
@@ -1,0 +1,8 @@
+import * as yup from 'yup'
+
+export const corpusTypeSchema = yup
+  .object({
+    name: yup.string().required(),
+    description: yup.string().required(),
+  })
+  .required()

--- a/src/tests/components/lists/CorpusTypeList.test.tsx
+++ b/src/tests/components/lists/CorpusTypeList.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import useCorpusTypes from '@/hooks/useCorpusTypes'
+import '../../setup'
+import { ICorpusType } from '@/interfaces/CorpusType'
+import { TestWrapper } from '@/tests/utilsTest/render'
+import '@testing-library/jest-dom'
+import CorpusTypeList from '@/components/lists/CorpusTypeList'
+
+// Mock data needs to be defined before imports for vi.mock hoisting
+const mockCorpusTypes: ICorpusType[] = [
+  {
+    name: 'Test Corpus Type 1',
+    description: 'Test Type Description 1',
+  },
+  {
+    name: 'Test Corpus Type 2',
+    description: 'Test Type Description 2',
+  },
+] as const
+
+const mockUseCorpusTypes = useCorpusTypes as unknown as ReturnType<typeof vi.fn>
+
+// Mock modules before imports
+vi.mock('@/hooks/useCorpusTypes', () => ({
+  default: vi.fn(),
+}))
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...(actual as object),
+    useNavigate: () => vi.fn(),
+  }
+})
+
+const renderComponent = () => {
+  return render(
+    <TestWrapper>
+      <CorpusTypeList />
+    </TestWrapper>,
+  )
+}
+
+describe('CorpusList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseCorpusTypes.mockReturnValue({
+      corpusTypes: mockCorpusTypes,
+      loading: false,
+      error: null,
+    })
+  })
+
+  it('renders list of corpus types', () => {
+    renderComponent()
+    expect(screen.getByText('Test Corpus Type 1')).toBeInTheDocument()
+    expect(screen.getByText('Test Corpus Type 2')).toBeInTheDocument()
+  })
+
+  it('shows loading state', () => {
+    mockUseCorpusTypes.mockReturnValue({
+      corpusTypes: [],
+      loading: true,
+      error: null,
+      reload: vi.fn(),
+    } as const)
+
+    renderComponent()
+    expect(screen.getByText(/loading/i)).toBeInTheDocument()
+  })
+
+  it('displays correct table headings', () => {
+    renderComponent()
+
+    // Check total number of headings
+    const headings = screen.getAllByRole('columnheader')
+    expect(headings).toHaveLength(3)
+
+    // Check specific heading text
+    expect(screen.getByText('Name')).toBeInTheDocument()
+    expect(screen.getByText('Description')).toBeInTheDocument()
+  })
+
+  it('displays corpus data in correct columns', () => {
+    renderComponent()
+
+    // Get all rows (excluding header)
+    const rows = screen.getAllByRole('row').slice(1)
+
+    // Check first corpus row
+    const firstRowCells = rows[0].querySelectorAll('td')
+    expect(firstRowCells[0]).toHaveTextContent(mockCorpusTypes[0].name)
+    expect(firstRowCells[1]).toHaveTextContent(
+      mockCorpusTypes[0].description || '',
+    )
+
+    // Check second corpus row
+    const secondRowCells = rows[1].querySelectorAll('td')
+    expect(secondRowCells[0]).toHaveTextContent(mockCorpusTypes[1].name)
+    expect(secondRowCells[1]).toHaveTextContent(
+      mockCorpusTypes[1].description || '',
+    )
+
+    // Check edit buttons
+    const editButtons = screen.getAllByRole('button', {
+      name: /edit corpus type/i,
+    })
+    expect(editButtons).toHaveLength(mockCorpusTypes.length)
+
+    // Verify each edit button has the correct link
+    editButtons.forEach((button, index) => {
+      const link = button.closest('a')
+      expect(link).toHaveAttribute(
+        'href',
+        `/corpus-type/${mockCorpusTypes[index].name}/edit`,
+      )
+    })
+  })
+
+  it('shows error state', () => {
+    mockUseCorpusTypes.mockReturnValue({
+      corpusTypes: [],
+      loading: false,
+      error: new Error('Test error'),
+      reload: vi.fn(),
+    } as const)
+
+    renderComponent()
+    expect(screen.getByText(/error/i)).toBeInTheDocument()
+  })
+
+  it('navigates to edit corpus type page on edit button click', () => {
+    renderComponent()
+
+    const editButtons = screen.getAllByRole('button', {
+      name: /edit corpus type/i,
+    })
+    const firstEditButton = editButtons[0]
+    const link = firstEditButton.closest('a')
+
+    expect(link).toHaveAttribute(
+      'href',
+      `/corpus-type/${mockCorpusTypes[0].name}/edit`,
+    )
+  })
+})

--- a/src/views/corpusTypes/CorpusType.tsx
+++ b/src/views/corpusTypes/CorpusType.tsx
@@ -1,0 +1,77 @@
+import { useParams, Link as RouterLink } from 'react-router-dom'
+import {
+  Link,
+  Box,
+  Heading,
+  Text,
+  Button,
+  SkeletonText,
+} from '@chakra-ui/react'
+import { ArrowBackIcon } from '@chakra-ui/icons'
+import { Loader } from '@/components/Loader'
+import { ApiError } from '@/components/feedback/ApiError'
+import useCorpusType from '@/hooks/useCorpusType'
+import { CorpusTypeForm } from '@/components/forms/CorpusTypeForm'
+
+export default function CorpusType() {
+  const { name } = useParams()
+  const { corpusType, loading, error } = useCorpusType(name)
+
+  const canLoadForm = !loading && !error
+  const pageTitle = loading
+    ? 'Loading...'
+    : corpusType
+      ? `Editing: ${corpusType.name}`
+      : 'Create new corpus type'
+
+  return (
+    <>
+      <Box display='flex'>
+        <Link
+          as={RouterLink}
+          to='/corpus-types'
+          display='flex'
+          alignItems='center'
+        >
+          <ArrowBackIcon mr='2' /> Back to corpus types
+        </Link>
+      </Box>
+      <Heading as={'h1'}>{pageTitle}</Heading>
+      <Text>
+        <Text as='span' color={'red.500'}>
+          *
+        </Text>{' '}
+        indicates required fields
+      </Text>
+      <Box my={4} p={4} bg={'gray.50'} boxShadow='base'>
+        {error && (
+          <>
+            <ApiError error={error} />
+            <Button
+              as={RouterLink}
+              to={'/corpus-types'}
+              colorScheme='blue'
+              mt={4}
+            >
+              Back to corpus types
+            </Button>
+          </>
+        )}
+        {loading && (
+          <>
+            <Box padding='4' bg='white'>
+              <Loader />
+              <SkeletonText
+                mt='4'
+                noOfLines={12}
+                spacing='4'
+                skeletonHeight='2'
+              />
+            </Box>
+          </>
+        )}
+        {canLoadForm && <CorpusTypeForm corpusType={corpusType ?? undefined} />}
+      </Box>
+    </>
+  )
+}

--- a/src/views/corpusTypes/CorpusTypes.tsx
+++ b/src/views/corpusTypes/CorpusTypes.tsx
@@ -1,0 +1,29 @@
+import {
+  Box,
+  Button,
+  ButtonGroup,
+  Flex,
+  Heading,
+  Spacer,
+} from '@chakra-ui/react'
+import { Link, Outlet } from 'react-router-dom'
+
+export default function CorpusTypes() {
+  return (
+    <Flex gap={4} height={'100%'} flexDirection={'column'}>
+      <Flex alignItems='center' gap='4'>
+        <Box>
+          <Heading as={'h1'}>Corpus Types</Heading>
+        </Box>
+
+        <Spacer />
+        <ButtonGroup>
+          <Button as={Link} colorScheme='blue' to='/corpus-type/new'>
+            Add new Corpus Type
+          </Button>
+        </ButtonGroup>
+      </Flex>
+      <Outlet />
+    </Flex>
+  )
+}


### PR DESCRIPTION
# What's changed

Read corpus type information via admin service UI for superusers.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
