### PR TITLE
APP-210: Bug: Hyperlinks in Family summary disappeared once the entries were published

### DIFF
--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -34,7 +34,7 @@ import {
 import { canModify } from '@/utils/canModify'
 import { getCountries } from '@/utils/extractNestedGeographyData'
 import { decodeToken } from '@/utils/decodeToken'
-import { stripHtmlForRichText } from '@/utils/stripHtml'
+import { stripHtml } from '@/utils/stripHtml'
 import { generateDynamicValidationSchema } from '@/schemas/dynamicValidationSchema'
 import { createFamily, updateFamily } from '@/api/Families'
 import { deleteDocument } from '@/api/Documents'
@@ -211,7 +211,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
     // Prepare base family data common to all types
     const baseData: IFamilyFormPostBase = {
       title: formData.title,
-      summary: stripHtmlForRichText(formData.summary),
+      summary: stripHtml(formData.summary),
       // We still expect this value in the backend
       geography: formData.geographies?.[0].value || '',
       geographies: formData.geographies?.map((geo) => geo.value),
@@ -414,10 +414,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
   }
 
   const summaryOnChange = (html: string) => {
-    if (
-      stripHtmlForRichText(html) === '' ||
-      loadedFamily?.summary === stripHtmlForRichText(html)
-    ) {
+    if (stripHtml(html) === '' || loadedFamily?.summary === stripHtml(html)) {
       return
     }
     setValue('summary', html, { shouldDirty: true })

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -34,7 +34,7 @@ import {
 import { canModify } from '@/utils/canModify'
 import { getCountries } from '@/utils/extractNestedGeographyData'
 import { decodeToken } from '@/utils/decodeToken'
-import { stripHtml } from '@/utils/stripHtml'
+import { stripHtmlForRichText } from '@/utils/stripHtml'
 import { generateDynamicValidationSchema } from '@/schemas/dynamicValidationSchema'
 import { createFamily, updateFamily } from '@/api/Families'
 import { deleteDocument } from '@/api/Documents'
@@ -211,7 +211,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
     // Prepare base family data common to all types
     const baseData: IFamilyFormPostBase = {
       title: formData.title,
-      summary: stripHtml(formData.summary),
+      summary: stripHtmlForRichText(formData.summary),
       // We still expect this value in the backend
       geography: formData.geographies?.[0].value || '',
       geographies: formData.geographies?.map((geo) => geo.value),
@@ -414,7 +414,10 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
   }
 
   const summaryOnChange = (html: string) => {
-    if (stripHtml(html) === '' || loadedFamily?.summary === stripHtml(html)) {
+    if (
+      stripHtmlForRichText(html) === '' ||
+      loadedFamily?.summary === stripHtmlForRichText(html)
+    ) {
       return
     }
     setValue('summary', html, { shouldDirty: true })

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -1,64 +1,64 @@
-import { useEffect, useState, useMemo, useCallback } from 'react'
-import { useForm, SubmitHandler, SubmitErrorHandler } from 'react-hook-form'
-import { yupResolver } from '@hookform/resolvers/yup'
-import { useBlocker, useNavigate } from 'react-router-dom'
+import useCollections from '@/hooks/useCollections'
+import useConfig from '@/hooks/useConfig'
+import useCorpusFromConfig from '@/hooks/useCorpusFromConfig'
 import {
-  VStack,
   Button,
   ButtonGroup,
-  useToast,
   SkeletonText,
   useDisclosure,
+  useToast,
+  VStack,
 } from '@chakra-ui/react'
+import { yupResolver } from '@hookform/resolvers/yup'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { SubmitErrorHandler, SubmitHandler, useForm } from 'react-hook-form'
+import { useBlocker, useNavigate } from 'react-router-dom'
 import * as yup from 'yup'
-import useCorpusFromConfig from '@/hooks/useCorpusFromConfig'
-import useConfig from '@/hooks/useConfig'
-import useCollections from '@/hooks/useCollections'
 
+import { EntityEditDrawer } from '../drawers/EntityEditDrawer'
+import { ReadOnlyFields } from '../family/ReadOnlyFields'
+import { RadioGroupField } from './fields/RadioGroupField'
 import { SelectField } from './fields/SelectField'
 import { TextField } from './fields/TextField'
-import { RadioGroupField } from './fields/RadioGroupField'
 import { WYSIWYGField } from './fields/WYSIWYGField'
-import { MetadataSection } from './sections/MetadataSection'
+import { UnsavedChangesModal } from './modals/UnsavedChangesModal'
 import { DocumentSection } from './sections/DocumentSection'
 import { EventSection } from './sections/EventSection'
-import { UnsavedChangesModal } from './modals/UnsavedChangesModal'
-import { ReadOnlyFields } from '../family/ReadOnlyFields'
-import { EntityEditDrawer } from '../drawers/EntityEditDrawer'
+import { MetadataSection } from './sections/MetadataSection'
 
-import {
-  TFamily,
-  IFamilyFormPostBase,
-  TFamilyMetadata,
-} from '@/interfaces/Family'
-import { canModify } from '@/utils/canModify'
-import { getCountries } from '@/utils/extractNestedGeographyData'
-import { decodeToken } from '@/utils/decodeToken'
-import { stripHtml } from '@/utils/stripHtml'
-import { generateDynamicValidationSchema } from '@/schemas/dynamicValidationSchema'
-import { createFamily, updateFamily } from '@/api/Families'
 import { deleteDocument } from '@/api/Documents'
 import { deleteEvent } from '@/api/Events'
-import { createFamilySchema } from '@/schemas/familySchema'
-import { ApiError } from '../feedback/ApiError'
-import { IDocument } from '@/interfaces/Document'
-import { IEvent } from '@/interfaces/Event'
-import { IError } from '@/interfaces/Auth'
+import { createFamily, updateFamily } from '@/api/Families'
 import {
   IChakraSelect,
   ICollection,
   IConfigCorpora,
   TTaxonomy,
 } from '@/interfaces'
+import { IError } from '@/interfaces/Auth'
+import { IDocument } from '@/interfaces/Document'
+import { IEvent } from '@/interfaces/Event'
 import {
-  getMetadataHandler,
-  TFamilyFormSubmit,
-} from './metadata-handlers/familyForm'
+  IFamilyFormPostBase,
+  TFamily,
+  TFamilyMetadata,
+} from '@/interfaces/Family'
 import {
   CORPUS_METADATA_CONFIG,
   FieldType,
   IFormMetadata,
 } from '@/interfaces/Metadata'
+import { generateDynamicValidationSchema } from '@/schemas/dynamicValidationSchema'
+import { createFamilySchema } from '@/schemas/familySchema'
+import { canModify } from '@/utils/canModify'
+import { decodeToken } from '@/utils/decodeToken'
+import { getCountries } from '@/utils/extractNestedGeographyData'
+import { stripHtml } from '@/utils/stripHtml'
+import { ApiError } from '../feedback/ApiError'
+import {
+  getMetadataHandler,
+  TFamilyFormSubmit,
+} from './metadata-handlers/familyForm'
 export interface IFamilyFormBase {
   title: string
   summary: string

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -1,64 +1,64 @@
-import useCollections from '@/hooks/useCollections'
-import useConfig from '@/hooks/useConfig'
-import useCorpusFromConfig from '@/hooks/useCorpusFromConfig'
+import { useEffect, useState, useMemo, useCallback } from 'react'
+import { useForm, SubmitHandler, SubmitErrorHandler } from 'react-hook-form'
+import { yupResolver } from '@hookform/resolvers/yup'
+import { useBlocker, useNavigate } from 'react-router-dom'
 import {
+  VStack,
   Button,
   ButtonGroup,
+  useToast,
   SkeletonText,
   useDisclosure,
-  useToast,
-  VStack,
 } from '@chakra-ui/react'
-import { yupResolver } from '@hookform/resolvers/yup'
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import { SubmitErrorHandler, SubmitHandler, useForm } from 'react-hook-form'
-import { useBlocker, useNavigate } from 'react-router-dom'
 import * as yup from 'yup'
+import useCorpusFromConfig from '@/hooks/useCorpusFromConfig'
+import useConfig from '@/hooks/useConfig'
+import useCollections from '@/hooks/useCollections'
 
-import { EntityEditDrawer } from '../drawers/EntityEditDrawer'
-import { ReadOnlyFields } from '../family/ReadOnlyFields'
-import { RadioGroupField } from './fields/RadioGroupField'
 import { SelectField } from './fields/SelectField'
 import { TextField } from './fields/TextField'
+import { RadioGroupField } from './fields/RadioGroupField'
 import { WYSIWYGField } from './fields/WYSIWYGField'
-import { UnsavedChangesModal } from './modals/UnsavedChangesModal'
+import { MetadataSection } from './sections/MetadataSection'
 import { DocumentSection } from './sections/DocumentSection'
 import { EventSection } from './sections/EventSection'
-import { MetadataSection } from './sections/MetadataSection'
+import { UnsavedChangesModal } from './modals/UnsavedChangesModal'
+import { ReadOnlyFields } from '../family/ReadOnlyFields'
+import { EntityEditDrawer } from '../drawers/EntityEditDrawer'
 
+import {
+  TFamily,
+  IFamilyFormPostBase,
+  TFamilyMetadata,
+} from '@/interfaces/Family'
+import { canModify } from '@/utils/canModify'
+import { getCountries } from '@/utils/extractNestedGeographyData'
+import { decodeToken } from '@/utils/decodeToken'
+import { stripHtml } from '@/utils/stripHtml'
+import { generateDynamicValidationSchema } from '@/schemas/dynamicValidationSchema'
+import { createFamily, updateFamily } from '@/api/Families'
 import { deleteDocument } from '@/api/Documents'
 import { deleteEvent } from '@/api/Events'
-import { createFamily, updateFamily } from '@/api/Families'
+import { createFamilySchema } from '@/schemas/familySchema'
+import { ApiError } from '../feedback/ApiError'
+import { IDocument } from '@/interfaces/Document'
+import { IEvent } from '@/interfaces/Event'
+import { IError } from '@/interfaces/Auth'
 import {
   IChakraSelect,
   ICollection,
   IConfigCorpora,
   TTaxonomy,
 } from '@/interfaces'
-import { IError } from '@/interfaces/Auth'
-import { IDocument } from '@/interfaces/Document'
-import { IEvent } from '@/interfaces/Event'
 import {
-  IFamilyFormPostBase,
-  TFamily,
-  TFamilyMetadata,
-} from '@/interfaces/Family'
+  getMetadataHandler,
+  TFamilyFormSubmit,
+} from './metadata-handlers/familyForm'
 import {
   CORPUS_METADATA_CONFIG,
   FieldType,
   IFormMetadata,
 } from '@/interfaces/Metadata'
-import { generateDynamicValidationSchema } from '@/schemas/dynamicValidationSchema'
-import { createFamilySchema } from '@/schemas/familySchema'
-import { canModify } from '@/utils/canModify'
-import { decodeToken } from '@/utils/decodeToken'
-import { getCountries } from '@/utils/extractNestedGeographyData'
-import { stripHtml } from '@/utils/stripHtml'
-import { ApiError } from '../feedback/ApiError'
-import {
-  getMetadataHandler,
-  TFamilyFormSubmit,
-} from './metadata-handlers/familyForm'
 export interface IFamilyFormBase {
   title: string
   summary: string

--- a/src/tests/components/forms/CorpusForm.test.tsx
+++ b/src/tests/components/forms/CorpusForm.test.tsx
@@ -467,7 +467,7 @@ describe('CorpusForm', () => {
         description: 'Original Description',
         organisation_id: 1,
         organisation_name: 'Test Organisation 1',
-        corpus_text: 'TBD',
+        corpus_text: '<p>TBD</p>',
         corpus_image_url: null,
         corpus_type_name: 'Test Corpus Type 1',
         corpus_type_description: 'Test Corpus Type Description 1',
@@ -529,7 +529,7 @@ describe('CorpusForm', () => {
           expect.objectContaining({
             title: 'Updated Corpus',
             description: 'Updated Description',
-            corpus_text: 'TBD',
+            corpus_text: '<p>TBD</p>',
             corpus_image_url: null,
             corpus_type_description: 'Test Corpus Type Description 1',
           }),

--- a/src/tests/utils/stripHtml.test.ts
+++ b/src/tests/utils/stripHtml.test.ts
@@ -1,12 +1,15 @@
-import { stripHtml } from '@/utils/stripHtml'
+import { stripHtmlForRichText } from '@/utils/stripHtml'
 
-const expectNoStrip = (html: string) => expect(stripHtml(html)).toBe(html)
+const expectNoStrip = (html: string) =>
+  expect(stripHtmlForRichText(html)).toBe(html)
 
-describe('stripHtml', () => {
+describe('stripHtmlForRichText', () => {
   it('strips most html tags', () => {
-    expect(stripHtml('<img src="image.jpg />')).toBe('')
-    expect(stripHtml('line<br>break')).toBe('linebreak')
-    expect(stripHtml('<div>Other elements</div>')).toBe('Other elements')
+    expect(stripHtmlForRichText('<img src="image.jpg />')).toBe('')
+    expect(stripHtmlForRichText('line<br>break')).toBe('linebreak')
+    expect(stripHtmlForRichText('<div>Other elements</div>')).toBe(
+      'Other elements',
+    )
   })
 
   it('does not strip allowed html tags', () => {
@@ -19,15 +22,21 @@ describe('stripHtml', () => {
   })
 
   it('casts legacy typographic html tags to ones our WYSIWYG supports', () => {
-    expect(stripHtml('<b>bold</b>')).toBe('<strong>bold</strong>')
-    expect(stripHtml('<i>italic</i>')).toBe('<em>italic</em>')
-    expect(stripHtml('<U>underline</U>')).toBe('<ins>underline</ins>')
+    expect(stripHtmlForRichText('<b>bold</b>')).toBe('<strong>bold</strong>')
+    expect(stripHtmlForRichText('<i>italic</i>')).toBe('<em>italic</em>')
+    expect(stripHtmlForRichText('<U>underline</U>')).toBe(
+      '<ins>underline</ins>',
+    )
   })
 
   it('removes style attributes from allowed tags', () => {
-    expect(stripHtml('<p style="color:red;">red</p>')).toBe('<p>red</p>')
+    expect(stripHtmlForRichText('<p style="color:red;">red</p>')).toBe(
+      '<p>red</p>',
+    )
     expect(
-      stripHtml('<p\n      style="font-weight:bold" id="bold">bold</p>'),
+      stripHtmlForRichText(
+        '<p\n      style="font-weight:bold" id="bold">bold</p>',
+      ),
     ).toBe('<p id="bold">bold</p>')
   })
 })

--- a/src/tests/utils/stripHtml.test.ts
+++ b/src/tests/utils/stripHtml.test.ts
@@ -24,5 +24,10 @@ describe('stripHtml', () => {
     expect(stripHtml('<U>underline</U>')).toBe('<ins>underline</ins>')
   })
 
-  // TODO test attributes remain intact
+  it('removes style attributes from allowed tags', () => {
+    expect(stripHtml('<p style="color:red;">red</p>')).toBe('<p>red</p>')
+    expect(
+      stripHtml('<p\n      style="font-weight:bold" id="bold">bold</p>'),
+    ).toBe('<p id="bold">bold</p>')
+  })
 })

--- a/src/tests/utils/stripHtml.test.ts
+++ b/src/tests/utils/stripHtml.test.ts
@@ -1,0 +1,26 @@
+import { stripHtml } from '@/utils/stripHtml'
+
+const expectNoStrip = (html: string) => expect(stripHtml(html)).toBe(html)
+
+describe('stripHtml', () => {
+  it('strips most html tags', () => {
+    expect(stripHtml('<img src="image.jpg />')).toBe('')
+    expect(stripHtml('line<br>break')).toBe('linebreak')
+    expect(stripHtml('<p>Paragraph of text</p>')).toBe('Paragraph of text')
+    expect(stripHtml('<div>Other elements</div>')).toBe('Other elements')
+  })
+
+  it('does not strip allowed html tags', () => {
+    expectNoStrip('<strong>strong</strong>')
+    expectNoStrip('<em>emphasis</em>')
+    expectNoStrip('<ul><li>unordered</li><li>list</li></ul')
+    expectNoStrip('<ol><li>unordered</li><li>list</li></ol')
+    expectNoStrip('<a href="https://climatepolicyradar.org">CPR</a>')
+  })
+
+  it('casts legacy typographic html tags to ones our WYSIWYG supports', () => {
+    expect(stripHtml('<b>bold</b>')).toBe('<strong>bold</strong>')
+    expect(stripHtml('<i>italic</i>')).toBe('<em>italic</em>')
+    expect(stripHtml('<u>underline</u>')).toBe('<ins>underline</ins>')
+  })
+})

--- a/src/tests/utils/stripHtml.test.ts
+++ b/src/tests/utils/stripHtml.test.ts
@@ -6,13 +6,13 @@ describe('stripHtml', () => {
   it('strips most html tags', () => {
     expect(stripHtml('<img src="image.jpg />')).toBe('')
     expect(stripHtml('line<br>break')).toBe('linebreak')
-    expect(stripHtml('<p>Paragraph of text</p>')).toBe('Paragraph of text')
     expect(stripHtml('<div>Other elements</div>')).toBe('Other elements')
   })
 
   it('does not strip allowed html tags', () => {
+    expectNoStrip('<p>Paragraph of text</p>')
     expectNoStrip('<strong>strong</strong>')
-    expectNoStrip('<em>emphasis</em>')
+    expectNoStrip('<EM>EMPHASIS</EM>')
     expectNoStrip('<ul><li>unordered</li><li>list</li></ul')
     expectNoStrip('<ol><li>unordered</li><li>list</li></ol')
     expectNoStrip('<a href="https://climatepolicyradar.org">CPR</a>')
@@ -21,6 +21,8 @@ describe('stripHtml', () => {
   it('casts legacy typographic html tags to ones our WYSIWYG supports', () => {
     expect(stripHtml('<b>bold</b>')).toBe('<strong>bold</strong>')
     expect(stripHtml('<i>italic</i>')).toBe('<em>italic</em>')
-    expect(stripHtml('<u>underline</u>')).toBe('<ins>underline</ins>')
+    expect(stripHtml('<U>underline</U>')).toBe('<ins>underline</ins>')
   })
+
+  // TODO test attributes remain intact
 })

--- a/src/tests/utils/stripHtml.test.ts
+++ b/src/tests/utils/stripHtml.test.ts
@@ -1,15 +1,12 @@
-import { stripHtmlForRichText } from '@/utils/stripHtml'
+import { stripHtml } from '@/utils/stripHtml'
 
-const expectNoStrip = (html: string) =>
-  expect(stripHtmlForRichText(html)).toBe(html)
+const expectNoStrip = (html: string) => expect(stripHtml(html)).toBe(html)
 
-describe('stripHtmlForRichText', () => {
+describe('stripHtml', () => {
   it('strips most html tags', () => {
-    expect(stripHtmlForRichText('<img src="image.jpg />')).toBe('')
-    expect(stripHtmlForRichText('line<br>break')).toBe('linebreak')
-    expect(stripHtmlForRichText('<div>Other elements</div>')).toBe(
-      'Other elements',
-    )
+    expect(stripHtml('<img src="image.jpg />')).toBe('')
+    expect(stripHtml('line<br>break')).toBe('linebreak')
+    expect(stripHtml('<div>Other elements</div>')).toBe('Other elements')
   })
 
   it('does not strip allowed html tags', () => {
@@ -21,22 +18,21 @@ describe('stripHtmlForRichText', () => {
     expectNoStrip('<a href="https://climatepolicyradar.org">CPR</a>')
   })
 
+  it('strips a solitary empty paragraph', () => {
+    expect(stripHtml('<p></p>')).toBe('')
+    expect(stripHtml('<p></p>\n    ')).toBe('')
+  })
+
   it('casts legacy typographic html tags to ones our WYSIWYG supports', () => {
-    expect(stripHtmlForRichText('<b>bold</b>')).toBe('<strong>bold</strong>')
-    expect(stripHtmlForRichText('<i>italic</i>')).toBe('<em>italic</em>')
-    expect(stripHtmlForRichText('<U>underline</U>')).toBe(
-      '<ins>underline</ins>',
-    )
+    expect(stripHtml('<b>bold</b>')).toBe('<strong>bold</strong>')
+    expect(stripHtml('<i>italic</i>')).toBe('<em>italic</em>')
+    expect(stripHtml('<U>underline</U>')).toBe('<ins>underline</ins>')
   })
 
   it('removes style attributes from allowed tags', () => {
-    expect(stripHtmlForRichText('<p style="color:red;">red</p>')).toBe(
-      '<p>red</p>',
-    )
+    expect(stripHtml('<p style="color:red;">red</p>')).toBe('<p>red</p>')
     expect(
-      stripHtmlForRichText(
-        '<p\n      style="font-weight:bold" id="bold">bold</p>',
-      ),
+      stripHtml('<p\n      style="font-weight:bold" id="bold">bold</p>'),
     ).toBe('<p id="bold">bold</p>')
   })
 })

--- a/src/utils/stripHtml.ts
+++ b/src/utils/stripHtml.ts
@@ -18,7 +18,7 @@ const REPLACE_TAGS: Record<string, string> = {
   u: 'ins',
 }
 
-export const stripHtml = (html: string) => {
+export const stripHtmlForRichText = (html: string) => {
   return html
     .replace(/<\/*(\w+)[^>]*>?/gim, (match, tag: string) => {
       const lowerCasedTag = tag.toLowerCase()
@@ -32,6 +32,13 @@ export const stripHtml = (html: string) => {
 
       return updatedMatch.replace(/\s+\bstyle="[^"]*?"/im, '')
     })
+    .replace(/&[^;]+;/g, '')
+    .trim()
+}
+
+export const stripHtml = (html: string) => {
+  return html
+    .replace(/<[^>]*>?/gm, '')
     .replace(/&[^;]+;/g, '')
     .trim()
 }

--- a/src/utils/stripHtml.ts
+++ b/src/utils/stripHtml.ts
@@ -1,6 +1,31 @@
+const ALLOWED_TAGS = [
+  'a',
+  'b',
+  'em',
+  'i',
+  'ins',
+  'li',
+  'ol',
+  'strong',
+  'u',
+  'ul',
+]
+
+const REPLACE: Record<string, string> = {
+  b: 'strong',
+  i: 'em',
+  u: 'ins',
+}
+
 export const stripHtml = (html: string) => {
   return html
-    .replace(/<[^>]*>?/gm, '')
+    .replace(/<\/*(\w+)[^>]*>?/gim, (match, tag: string) => {
+      if (!ALLOWED_TAGS.includes(tag)) return ''
+      if (!(tag in REPLACE)) return match
+
+      const newTag = REPLACE[tag]
+      return match.replace(/(<\/*)\w+/im, `$1${newTag}`)
+    })
     .replace(/&[^;]+;/g, '')
     .trim()
 }

--- a/src/utils/stripHtml.ts
+++ b/src/utils/stripHtml.ts
@@ -18,8 +18,8 @@ const REPLACE_TAGS: Record<string, string> = {
   u: 'ins',
 }
 
-export const stripHtmlForRichText = (html: string) => {
-  return html
+export const stripHtml = (html: string) => {
+  const strippedHtml = html
     .replace(/<\/*(\w+)[^>]*>?/gim, (match, tag: string) => {
       const lowerCasedTag = tag.toLowerCase()
 
@@ -34,11 +34,6 @@ export const stripHtmlForRichText = (html: string) => {
     })
     .replace(/&[^;]+;/g, '')
     .trim()
-}
 
-export const stripHtml = (html: string) => {
-  return html
-    .replace(/<[^>]*>?/gm, '')
-    .replace(/&[^;]+;/g, '')
-    .trim()
+  return strippedHtml === '<p></p>' ? '' : strippedHtml
 }

--- a/src/utils/stripHtml.ts
+++ b/src/utils/stripHtml.ts
@@ -6,6 +6,7 @@ const ALLOWED_TAGS = [
   'ins',
   'li',
   'ol',
+  'p',
   'strong',
   'u',
   'ul',
@@ -20,10 +21,12 @@ const REPLACE: Record<string, string> = {
 export const stripHtml = (html: string) => {
   return html
     .replace(/<\/*(\w+)[^>]*>?/gim, (match, tag: string) => {
-      if (!ALLOWED_TAGS.includes(tag)) return ''
-      if (!(tag in REPLACE)) return match
+      const lowerCasedTag = tag.toLowerCase()
 
-      const newTag = REPLACE[tag]
+      if (!ALLOWED_TAGS.includes(lowerCasedTag)) return ''
+      if (!(lowerCasedTag in REPLACE)) return match
+
+      const newTag = REPLACE[lowerCasedTag]
       return match.replace(/(<\/*)\w+/im, `$1${newTag}`)
     })
     .replace(/&[^;]+;/g, '')

--- a/src/utils/stripHtml.ts
+++ b/src/utils/stripHtml.ts
@@ -12,7 +12,7 @@ const ALLOWED_TAGS = [
   'ul',
 ]
 
-const REPLACE: Record<string, string> = {
+const REPLACE_TAGS: Record<string, string> = {
   b: 'strong',
   i: 'em',
   u: 'ins',
@@ -26,8 +26,8 @@ export const stripHtml = (html: string) => {
       if (!ALLOWED_TAGS.includes(lowerCasedTag)) return ''
 
       const updatedMatch =
-        lowerCasedTag in REPLACE
-          ? match.replace(/(<\/*)\w+/im, `$1${REPLACE[lowerCasedTag]}`)
+        lowerCasedTag in REPLACE_TAGS
+          ? match.replace(/(<\/*)\w+/im, `$1${REPLACE_TAGS[lowerCasedTag]}`)
           : match
 
       return updatedMatch.replace(/\s+\bstyle="[^"]*?"/im, '')

--- a/src/utils/stripHtml.ts
+++ b/src/utils/stripHtml.ts
@@ -24,10 +24,13 @@ export const stripHtml = (html: string) => {
       const lowerCasedTag = tag.toLowerCase()
 
       if (!ALLOWED_TAGS.includes(lowerCasedTag)) return ''
-      if (!(lowerCasedTag in REPLACE)) return match
 
-      const newTag = REPLACE[lowerCasedTag]
-      return match.replace(/(<\/*)\w+/im, `$1${newTag}`)
+      const updatedMatch =
+        lowerCasedTag in REPLACE
+          ? match.replace(/(<\/*)\w+/im, `$1${REPLACE[lowerCasedTag]}`)
+          : match
+
+      return updatedMatch.replace(/\s+\bstyle="[^"]*?"/im, '')
     })
     .replace(/&[^;]+;/g, '')
     .trim()


### PR DESCRIPTION
# What's changed

Addresses a bug where HTML markup is too aggressively stripped from the family summary when the page is saved. This happens before sending an API request. Instead, this PR introduces some sympathetic allowances to increase the ease of copy/paste from documents.

- Added `stripHtmlForRichText` utility:
  - Replacing HTML tags uses a `String.match` function for greater control over what the replacement text is.
  - Tags listed in the `ALLOWED_TAGS` array aren't stripped in their entirety anymore. This is links and some typographic styles including lists.
  - Converts some tags listed in `REPLACE_TAGS` so that they match the HTML tags being used by `draft-js` (WYSIWYG text editor).
  - Strip `style` attributes from all tags to purge any word processor styling copied across.
- Tests for `stripHtmlForRichText` utility.
- `stripHtml` continues to be used in `CorpusForm`, `stripHtmlForRichText` is used in `FamilyForm`.

_After pasting an example from Google Drive:_
<img width="998" alt="Screenshot 2025-02-13 at 16 21 26" src="https://github.com/user-attachments/assets/7f48f65f-97c8-453b-a447-acf13d5ce1c4" />

_After saving the example. Note the link is no longer blue but still functions as a hyperlink:_
<img width="996" alt="Screenshot 2025-02-13 at 16 21 53" src="https://github.com/user-attachments/assets/858d876c-296a-4797-874e-8e0bf6971734" />

## Proposed version

- [x] Patch