### PR TITLE
Feature/app 229 create app tokens via admin service UI

### DIFF
--- a/src/api/AppToken.ts
+++ b/src/api/AppToken.ts
@@ -1,0 +1,25 @@
+import { AxiosError } from 'axios'
+
+import API from '@/api'
+import { setToken } from '@/api/Auth'
+import { IError } from '@/interfaces'
+import { IAppTokenFormPost } from '@/interfaces/AppToken'
+
+export async function createAppToken(data: IAppTokenFormPost) {
+  setToken(API)
+
+  const response = await API.post<string>('/v1/app-tokens', data)
+    .then((response) => {
+      return response.data
+    })
+    .catch((error: AxiosError<{ detail: string }>) => {
+      const e: IError = {
+        status: error.response?.status || 500,
+        detail: error.response?.data?.detail || 'Unknown error',
+        message: error.message,
+      }
+      throw e
+    })
+
+  return { response }
+}

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -120,10 +120,6 @@ export function SideMenu() {
                     >
                       Corpora
                     </IconLink>
-                  </>
-                )}
-                {isSuperUser && (
-                  <>
                     <IconLink
                       icon={<Icon as={GoLog} mr='2' />}
                       to='/corpus-types'
@@ -131,16 +127,19 @@ export function SideMenu() {
                     >
                       Corpus Types
                     </IconLink>
-                  </>
-                )}
-                {isSuperUser && (
-                  <>
                     <IconLink
                       icon={<Icon as={GoLog} mr='2' />}
                       to='/organisations'
                       current={isCurrentPage('organisations')}
                     >
                       Organisations
+                    </IconLink>
+                    <IconLink
+                      icon={<Icon as={GoLog} mr='2' />}
+                      to='/app-tokens/new'
+                      current={isCurrentPage('app-tokens')}
+                    >
+                      Create App Token
                     </IconLink>
                   </>
                 )}

--- a/src/components/forms/AppTokenForm.tsx
+++ b/src/components/forms/AppTokenForm.tsx
@@ -23,16 +23,20 @@ import {
   Box,
   Code,
   useClipboard,
+  Input,
+  Divider,
+  IconButton,
 } from '@chakra-ui/react'
 import { useNavigate } from 'react-router-dom'
 import { ApiError } from '../feedback/ApiError'
-import { InfoOutlineIcon } from '@chakra-ui/icons'
+import { InfoOutlineIcon, CopyIcon } from '@chakra-ui/icons'
 import { TextField } from './fields/TextField'
 import { FormLoader } from '../feedback/FormLoader'
 import { IAppTokenFormPost } from '@/interfaces/AppToken'
 import useCorpora from '@/hooks/useCorpora'
 import * as Yup from 'yup'
 import { SelectField } from '@/components/forms/fields/SelectField'
+import { jwtDecode } from 'jwt-decode'
 
 type TProps = {
   corpus?: ICorpus
@@ -40,12 +44,19 @@ type TProps = {
 
 export type IAppTokenFormSubmit = Yup.InferType<typeof appTokenSchema>
 
+interface JWTPayload {
+  sub: string
+  aud: string
+  allowed_corpora_ids?: string[]
+}
+
 export const AppTokenForm = ({ corpus: loadedCorpus }: TProps) => {
   const navigate = useNavigate()
   const toast = useToast()
   const [formError, setFormError] = useState<IError | null | undefined>()
   const [createdAppToken, setCreatedAppToken] = useState<string | null>(null)
   const { onCopy, hasCopied } = useClipboard(createdAppToken || '')
+  const [pastedToken, setPastedToken] = useState<string>('')
 
   const {
     register,
@@ -61,6 +72,50 @@ export const AppTokenForm = ({ corpus: loadedCorpus }: TProps) => {
   })
 
   const { corpora, error: corporaError, loading: corporaLoading } = useCorpora()
+
+  const handleTokenPaste = useCallback(() => {
+    try {
+      const decoded = jwtDecode<JWTPayload>(pastedToken)
+
+      // Populate theme (subject)
+      if (decoded.sub) setValue('theme', decoded.sub)
+
+      // Populate hostname (audience)
+      if (decoded.aud) {
+        const httpScheme = decoded.aud.includes('localhost')
+          ? 'http://'
+          : 'https://'
+        setValue('hostname', httpScheme + decoded.aud)
+      }
+
+      // Populate corpora IDs
+      if (decoded.allowed_corpora_ids?.length) {
+        const matchingCorpora = corpora.filter((corpus) =>
+          decoded.allowed_corpora_ids?.includes(corpus.import_id),
+        )
+
+        const corporaOptions = matchingCorpora.map((corpus) => ({
+          value: corpus.import_id,
+          label: corpus.title,
+        }))
+
+        setValue('corpora_ids', corporaOptions)
+      }
+
+      toast({
+        title: 'Token decoded successfully',
+        status: 'success',
+        position: 'top',
+      })
+    } catch (error) {
+      toast({
+        title: 'Invalid token',
+        description: 'Could not decode the provided token',
+        status: 'error',
+        position: 'top',
+      })
+    }
+  }, [pastedToken, corpora, setValue, toast])
 
   const handleFormSubmission = useCallback(
     async (formValues: IAppTokenFormSubmit) => {
@@ -79,12 +134,15 @@ export const AppTokenForm = ({ corpus: loadedCorpus }: TProps) => {
         .then((response) => {
           const appToken = response.response
           toast.closeAll()
-          toast({
-            title: 'App token has been successfully created',
-            status: 'success',
-            position: 'top',
-          })
           setCreatedAppToken(appToken)
+          // Copy token to clipboard on create success
+          navigator.clipboard.writeText(appToken).then(() => {
+            toast({
+              title: 'App token copied to clipboard',
+              status: 'success',
+              position: 'top',
+            })
+          })
         })
         .catch((error: IError) => {
           console.error('❌ Error during form submission:', error)
@@ -116,34 +174,6 @@ export const AppTokenForm = ({ corpus: loadedCorpus }: TProps) => {
       console.error(errors)
     }, [])
 
-  // useEffect(() => {
-  //   if (loadedCorpus && !configLoading) {
-
-  //     reset({
-  //       import_id: loadedCorpus.import_id || '',
-  //       title: loadedCorpus.title || '',
-  //       description: loadedCorpus.description || '',
-  //       corpus_text: loadedCorpus.corpus_text || '',
-  //       corpus_image_url: loadedCorpus.corpus_image_url || '',
-  //       corpus_type_name: loadedCorpus.corpus_type_name
-  //         ? {
-  //             label: loadedCorpus.corpus_type_name,
-  //             value: loadedCorpus.corpus_type_name,
-  //           }
-  //         : undefined,
-  //       corpus_type_description: loadedCorpus.corpus_type_description || '',
-  //       organisation_id: loadedCorpus.organisation_id
-  //         ? {
-  //             label: orgName,
-  //             value: loadedCorpus.organisation_id,
-  //           }
-  //         : undefined,
-  //     })
-  //     updateCorpusTypeDescription(loadedCorpus.corpus_type_name)
-  //   }
-  //   // eslint-disable-next-line react-hooks/exhaustive-deps
-  // }, [loadedCorpus, configLoading, getOrganisationDisplayNameById, reset])
-
   return (
     <>
       {corporaError && <ApiError error={corporaError} />}
@@ -158,26 +188,48 @@ export const AppTokenForm = ({ corpus: loadedCorpus }: TProps) => {
               bg='green.50'
               p={4}
               borderRadius='md'
-              display='flex'
-              justifyContent='space-between'
-              alignItems='center'
+              onDoubleClick={() => {
+                onCopy()
+                toast({
+                  title: 'Token copied to clipboard',
+                  status: 'success',
+                  duration: 2000,
+                  position: 'top',
+                })
+              }}
             >
               <Code
-                children={createdAppToken}
                 p={2}
                 bg='green.100'
                 borderRadius='md'
-                mr={2}
-              />
-              <Button
-                onClick={onCopy}
-                size='sm'
-                colorScheme={hasCopied ? 'green' : 'blue'}
+                whiteSpace='normal'
+                wordBreak='break-all'
+                width='100%'
+                cursor='copy'
               >
-                {hasCopied ? 'Copied!' : 'Copy'}
-              </Button>
+                {createdAppToken}
+              </Code>
             </Box>
           )}
+
+          <FormControl>
+            <FormLabel>Paste Existing Token (Optional)</FormLabel>
+            <Input
+              placeholder='Paste your existing app token here'
+              value={pastedToken}
+              onChange={(e) => setPastedToken(e.target.value)}
+            />
+            <Button
+              mt={2}
+              size='sm'
+              onClick={handleTokenPaste}
+              isDisabled={!pastedToken}
+            >
+              Decode Token
+            </Button>
+          </FormControl>
+
+          <Divider />
 
           <TextField
             name='theme'

--- a/src/components/forms/AppTokenForm.tsx
+++ b/src/components/forms/AppTokenForm.tsx
@@ -32,8 +32,6 @@ import * as Yup from 'yup'
 import { SelectField } from '@/components/forms/fields/SelectField'
 import { jwtDecode } from 'jwt-decode'
 
-type TProps = {}
-
 export type IAppTokenFormSubmit = Yup.InferType<typeof appTokenSchema>
 
 interface JWTPayload {
@@ -42,7 +40,7 @@ interface JWTPayload {
   allowed_corpora_ids?: string[]
 }
 
-export const AppTokenForm = ({}: TProps) => {
+export const AppTokenForm = () => {
   const toast = useToast()
   const [formError, setFormError] = useState<IError | null | undefined>()
   const [createdAppToken, setCreatedAppToken] = useState<string | null>(null)
@@ -124,13 +122,25 @@ export const AppTokenForm = ({}: TProps) => {
           toast.closeAll()
           setCreatedAppToken(appToken)
           setPastedToken('')
-          navigator.clipboard.writeText(appToken).then(() => {
-            toast({
-              title: 'App token copied to clipboard',
-              status: 'success',
-              position: 'top',
+          navigator.clipboard
+            .writeText(appToken)
+            .then(() => {
+              toast({
+                title: 'App token copied to clipboard',
+                status: 'success',
+                duration: 2000,
+                position: 'top',
+              })
             })
-          })
+            .catch((error: IError) => {
+              toast({
+                title: 'Failed to copy token',
+                description: error.message,
+                status: 'error',
+                duration: 2000,
+                position: 'top',
+              })
+            })
         })
         .catch((error: IError) => {
           console.error('❌ Error during form submission:', error)
@@ -161,6 +171,12 @@ export const AppTokenForm = ({}: TProps) => {
     useCallback((errors) => {
       console.error(errors)
     }, [])
+
+  const handleReset = () => {
+    reset() // Reset form to initial values
+    setPastedToken('') // Clear pasted token
+    setCreatedAppToken(null) // Clear created token
+  }
 
   return (
     <>
@@ -276,6 +292,9 @@ export const AppTokenForm = ({}: TProps) => {
           <ButtonGroup>
             <Button type='submit' colorScheme='blue' disabled={isSubmitting}>
               {(createdAppToken ? 'Update ' : 'Create new ') + 'App Token'}
+            </Button>
+            <Button onClick={handleReset} variant='outline' colorScheme='red'>
+              Clear Form
             </Button>
           </ButtonGroup>
         </VStack>

--- a/src/components/forms/AppTokenForm.tsx
+++ b/src/components/forms/AppTokenForm.tsx
@@ -1,0 +1,224 @@
+import { useEffect, useRef, useState, useCallback } from 'react'
+import {
+  useForm,
+  SubmitHandler,
+  SubmitErrorHandler,
+  Controller,
+} from 'react-hook-form'
+import { yupResolver } from '@hookform/resolvers/yup'
+import { IChakraSelect, ICorpus, IError } from '@/interfaces'
+import { appTokenSchema } from '@/schemas/appTokenSchema'
+import { createAppToken } from '@/api/AppToken'
+import {
+  FormControl,
+  FormLabel,
+  Textarea,
+  VStack,
+  Button,
+  ButtonGroup,
+  FormErrorMessage,
+  useToast,
+  Tooltip,
+  Icon,
+  Box,
+  Code,
+  useClipboard,
+} from '@chakra-ui/react'
+import { useNavigate } from 'react-router-dom'
+import { ApiError } from '../feedback/ApiError'
+import { InfoOutlineIcon } from '@chakra-ui/icons'
+import { TextField } from './fields/TextField'
+import { FormLoader } from '../feedback/FormLoader'
+import { IAppTokenFormPost } from '@/interfaces/AppToken'
+import useCorpora from '@/hooks/useCorpora'
+import * as Yup from 'yup'
+import { SelectField } from '@/components/forms/fields/SelectField'
+
+type TProps = {
+  corpus?: ICorpus
+}
+
+export type IAppTokenFormSubmit = Yup.InferType<typeof appTokenSchema>
+
+export const AppTokenForm = ({ corpus: loadedCorpus }: TProps) => {
+  const navigate = useNavigate()
+  const toast = useToast()
+  const [formError, setFormError] = useState<IError | null | undefined>()
+  const [createdAppToken, setCreatedAppToken] = useState<string | null>(null)
+  const { onCopy, hasCopied } = useClipboard(createdAppToken || '')
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    reset,
+    formState: { errors, isSubmitting },
+    setValue,
+    getValues,
+    watch,
+  } = useForm<IAppTokenFormSubmit>({
+    resolver: yupResolver(appTokenSchema),
+  })
+
+  const { corpora, error: corporaError, loading: corporaLoading } = useCorpora()
+
+  const handleFormSubmission = useCallback(
+    async (formValues: IAppTokenFormSubmit) => {
+      setFormError(null)
+
+      const formData: IAppTokenFormPost = {
+        theme: formValues.theme,
+        hostname: formValues.hostname,
+        expiry_years: formValues.expiry_years,
+        corpora_ids: formValues.corpora_ids.map(
+          (corpus: IChakraSelect) => corpus.value,
+        ),
+      }
+
+      return await createAppToken(formData)
+        .then((response) => {
+          const appToken = response.response
+          toast.closeAll()
+          toast({
+            title: 'App token has been successfully created',
+            status: 'success',
+            position: 'top',
+          })
+          setCreatedAppToken(appToken)
+        })
+        .catch((error: IError) => {
+          console.error('❌ Error during form submission:', error)
+          setFormError(error)
+          toast({
+            title: 'App token has not been created',
+            description: error.message,
+            status: 'error',
+            position: 'top',
+          })
+        })
+    },
+    [loadedCorpus, navigate, toast, setFormError],
+  )
+
+  const onSubmit: SubmitHandler<IAppTokenFormSubmit> = useCallback(
+    (data) => {
+      // Reset created app token when a new submission starts
+      setCreatedAppToken(null)
+      handleFormSubmission(data).catch((error: IError) => {
+        console.error(error)
+      })
+    },
+    [handleFormSubmission],
+  )
+
+  const onSubmitErrorHandler: SubmitErrorHandler<IAppTokenFormSubmit> =
+    useCallback((errors) => {
+      console.error(errors)
+    }, [])
+
+  // useEffect(() => {
+  //   if (loadedCorpus && !configLoading) {
+
+  //     reset({
+  //       import_id: loadedCorpus.import_id || '',
+  //       title: loadedCorpus.title || '',
+  //       description: loadedCorpus.description || '',
+  //       corpus_text: loadedCorpus.corpus_text || '',
+  //       corpus_image_url: loadedCorpus.corpus_image_url || '',
+  //       corpus_type_name: loadedCorpus.corpus_type_name
+  //         ? {
+  //             label: loadedCorpus.corpus_type_name,
+  //             value: loadedCorpus.corpus_type_name,
+  //           }
+  //         : undefined,
+  //       corpus_type_description: loadedCorpus.corpus_type_description || '',
+  //       organisation_id: loadedCorpus.organisation_id
+  //         ? {
+  //             label: orgName,
+  //             value: loadedCorpus.organisation_id,
+  //           }
+  //         : undefined,
+  //     })
+  //     updateCorpusTypeDescription(loadedCorpus.corpus_type_name)
+  //   }
+  //   // eslint-disable-next-line react-hooks/exhaustive-deps
+  // }, [loadedCorpus, configLoading, getOrganisationDisplayNameById, reset])
+
+  return (
+    <>
+      {corporaError && <ApiError error={corporaError} />}
+      {corporaLoading && <FormLoader />}
+
+      <form onSubmit={handleSubmit(onSubmit, onSubmitErrorHandler)}>
+        <VStack gap='4' mb={12} align={'stretch'}>
+          {formError && <ApiError error={formError} />}
+
+          {createdAppToken && (
+            <Box
+              bg='green.50'
+              p={4}
+              borderRadius='md'
+              display='flex'
+              justifyContent='space-between'
+              alignItems='center'
+            >
+              <Code
+                children={createdAppToken}
+                p={2}
+                bg='green.100'
+                borderRadius='md'
+                mr={2}
+              />
+              <Button
+                onClick={onCopy}
+                size='sm'
+                colorScheme={hasCopied ? 'green' : 'blue'}
+              >
+                {hasCopied ? 'Copied!' : 'Copy'}
+              </Button>
+            </Box>
+          )}
+
+          <TextField
+            name='theme'
+            label='Theme'
+            control={control}
+            isRequired={true}
+          />
+
+          <TextField
+            name='hostname'
+            label={
+              <>
+                'Domain'
+                <Tooltip label='This is the internally used description of this corpus'>
+                  <Icon as={InfoOutlineIcon} ml={2} cursor='pointer' />
+                </Tooltip>
+              </>
+            }
+            control={control}
+            isRequired={true}
+          />
+
+          <SelectField
+            name='corpora_ids'
+            label='Allowed Corpora'
+            control={control}
+            options={corpora.map((corpus) => ({
+              value: corpus.import_id,
+              label: corpus.title,
+            }))}
+            isMulti={true}
+            isRequired={true}
+          />
+
+          <ButtonGroup>
+            <Button type='submit' colorScheme='blue' disabled={isSubmitting}>
+              {(loadedCorpus ? 'Update ' : 'Create new ') + 'App Token'}
+            </Button>
+          </ButtonGroup>
+        </VStack>
+      </form>
+    </>
+  )
+}

--- a/src/components/forms/fields/TextField.tsx
+++ b/src/components/forms/fields/TextField.tsx
@@ -14,7 +14,7 @@ type TProps<T extends FieldValues> = {
   control: Control<T>
   type?: 'text' | 'number'
   placeholder?: string
-  label?: string
+  label?: string | React.ReactNode
   isRequired?: boolean
   showHelperText?: boolean
   isDisabled?: boolean
@@ -50,7 +50,12 @@ export const TextField = <T extends FieldValues>({
                 {...field} // This destructured object contains the value
                 bg='white'
                 type={type}
-                placeholder={placeholder ?? `Enter ${label?.toLowerCase()}`}
+                placeholder={
+                  placeholder ??
+                  (typeof label === 'string'
+                    ? `Enter ${label?.toLowerCase()}`
+                    : placeholder)
+                }
                 value={field.value ?? ''} // this prevents the component changing from a controlled to uncontrolled component
               />
               {showHelperText && isDisabled && (

--- a/src/components/lists/CorpusList.tsx
+++ b/src/components/lists/CorpusList.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react'
-import { Link, useSearchParams } from 'react-router-dom'
-// import { deleteCorpus } from '@/api/Corpora'
+import { Link } from 'react-router-dom'
 import { ICorpus, IError } from '@/interfaces'
 import {
   Table,
@@ -30,8 +29,7 @@ export default function CorpusList() {
     reverse: boolean
   }>({ key: 'import_id', reverse: false })
   const [filteredItems, setFilteredItems] = useState<ICorpus[]>()
-  const [searchParams] = useSearchParams()
-  const { corpora, loading, error } = useCorpora(searchParams.get('q') ?? '')
+  const { corpora, loading, error } = useCorpora()
   const [corpusError] = useState<string | null | undefined>()
   const [formError] = useState<IError | null | undefined>()
 

--- a/src/hooks/useCorpora.ts
+++ b/src/hooks/useCorpora.ts
@@ -3,7 +3,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { IError, ICorpus } from '@/interfaces'
 import { getCorpora } from '@/api/Corpora'
 
-const useCorpora = (id: string) => {
+const useCorpora = () => {
   const [corpora, setCorpora] = useState<ICorpus[]>([])
   const [error, setError] = useState<IError | null | undefined>()
   const [loading, setLoading] = useState<boolean>(false)
@@ -12,7 +12,7 @@ const useCorpora = (id: string) => {
     setLoading(true)
     setError(null)
 
-    getCorpora(id)
+    getCorpora()
       .then(({ response }) => {
         setCorpora(response)
       })
@@ -22,7 +22,7 @@ const useCorpora = (id: string) => {
       .finally(() => {
         setLoading(false)
       })
-  }, [id])
+  }, [])
 
   const reload = () => {
     handleGetCorpora()

--- a/src/interfaces/AppToken.ts
+++ b/src/interfaces/AppToken.ts
@@ -2,7 +2,7 @@ export interface IAppTokenFormPost {
   corpora_ids: string[]
   theme: string
   hostname: string
-  expiry_years?: number
+  expiry_years: number | null
 }
 
 export interface IAppToken {

--- a/src/interfaces/AppToken.ts
+++ b/src/interfaces/AppToken.ts
@@ -1,0 +1,15 @@
+export interface IAppTokenFormPost {
+  corpora_ids: string[]
+  theme: string
+  hostname: string
+  expiry_years?: number
+}
+
+export interface IAppToken {
+  allowed_corpora_ids: string[]
+  sub: string
+  aud: string
+  iss: string
+  exp: number
+  iat: number
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -19,6 +19,7 @@ import CorpusType from '@/views/corpusTypes/CorpusType'
 import OrganisationList from '@/components/lists/OrganisationList'
 import Organisations from '@/views/organisation/Organisations'
 import Organisation from '@/views/organisation/Organisation'
+import { AppTokenForm } from '@/components/forms/AppTokenForm'
 
 const authenticatedRoutes = [
   {
@@ -122,6 +123,11 @@ const authenticatedRoutes = [
                     errorElement: <ErrorPage />,
                   },
                 ],
+              },
+              {
+                path: '/app-tokens/new',
+                element: <AppTokenForm />,
+                errorElement: <ErrorPage />,
               },
             ],
           },

--- a/src/schemas/appTokenSchema.ts
+++ b/src/schemas/appTokenSchema.ts
@@ -1,0 +1,10 @@
+import * as yup from 'yup'
+
+export const appTokenSchema = yup
+  .object({
+    theme: yup.string().required(),
+    hostname: yup.string().required(),
+    expiry_years: yup.number().optional().nullable(),
+    corpora_ids: yup.array().required('Corpora is required'),
+  })
+  .required()


### PR DESCRIPTION
# What's changed

Create app tokens via admin service UI (superuser only).

- Users can create from scratch
- Users can create using an existing token as a template

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
