### PR TITLE
Feature/app 343 tidy up duplicated event type taxonomy

### DIFF
--- a/src/components/forms/EventForm.tsx
+++ b/src/components/forms/EventForm.tsx
@@ -29,7 +29,7 @@ type TProps = {
   familyId?: string
   canModify?: boolean
   event?: IEvent
-  taxonomy?: TTaxonomy
+  taxonomy: TTaxonomy
   onSuccess?: (eventId: string) => void
 }
 
@@ -85,6 +85,11 @@ export const EventForm = ({
         event_title: event.event_title,
         date: eventDateFormatted,
         event_type_value: event.event_type_value,
+        metadata: {
+          event_type: [event.event_type_value],
+          datetime_event_name:
+            taxonomy._event.datetime_event_name.allowed_values,
+        },
       }
 
       try {
@@ -120,6 +125,11 @@ export const EventForm = ({
         event_title: event.event_title,
         date: eventDateFormatted,
         event_type_value: event.event_type_value,
+        metadata: {
+          event_type: [event.event_type_value],
+          datetime_event_name:
+            taxonomy._event.datetime_event_name.allowed_values,
+        },
       }
 
       try {

--- a/src/components/forms/EventForm.tsx
+++ b/src/components/forms/EventForm.tsx
@@ -180,18 +180,14 @@ export const EventForm = ({
               isReadOnly={!canModify}
             >
               {/* Add event type options from taxonomy if available */}
-              {taxonomy?.event_type &&
-                (Array.isArray(taxonomy.event_type)
-                  ? taxonomy.event_type.map((type: string) => (
-                      <option key={type} value={type}>
-                        {type}
-                      </option>
-                    ))
-                  : taxonomy.event_type.allowed_values?.map((type: string) => (
-                      <option key={type} value={type}>
-                        {type}
-                      </option>
-                    )))}
+              {taxonomy?._event?.event_type &&
+                taxonomy._event.event_type.allowed_values?.map(
+                  (type: string) => (
+                    <option key={type} value={type}>
+                      {type}
+                    </option>
+                  ),
+                )}
             </Select>
             {errors.event_type_value && (
               <FormErrorMessage>

--- a/src/components/forms/EventForm.tsx
+++ b/src/components/forms/EventForm.tsx
@@ -165,8 +165,14 @@ export const EventForm = ({
           </FormControl>
 
           <FormControl isRequired isInvalid={!!errors.date}>
-            <FormLabel>Date</FormLabel>
-            <Input type='date' {...register('date')} isReadOnly={!canModify} />
+            <FormLabel htmlFor='event-date'>Date</FormLabel>
+            <Input
+              id='event-date'
+              type='date'
+              {...register('date')}
+              isReadOnly={!canModify}
+              aria-label='Date'
+            />
             {errors.date && (
               <FormErrorMessage>{errors.date.message}</FormErrorMessage>
             )}

--- a/src/interfaces/Config.ts
+++ b/src/interfaces/Config.ts
@@ -55,7 +55,6 @@ export interface IConfigTaxonomyCCLW extends ITaxonomy {
   keyword: ITaxonomyField
   framework: ITaxonomyField
   instrument: ITaxonomyField
-  event_type: ITaxonomyField
   _document: IDefaultDocSubTaxonomy
   _event: IEventSubTaxonomy
 }
@@ -63,7 +62,6 @@ export interface IConfigTaxonomyCCLW extends ITaxonomy {
 export interface IConfigTaxonomyUNFCCC extends ITaxonomy {
   author: ITaxonomyField
   author_type: ITaxonomyField
-  event_type: ITaxonomyField
   _document: IDefaultDocSubTaxonomy
   _event: IEventSubTaxonomy
 }
@@ -71,13 +69,11 @@ export interface IConfigTaxonomyUNFCCC extends ITaxonomy {
 export interface IConfigReportsTaxonomy extends ITaxonomy {
   author: ITaxonomyField
   author_type: ITaxonomyField
-  event_type: ITaxonomyField
   _document: IReportsDocSubTaxonomy
   _event: IEventSubTaxonomy
 }
 
 interface IConfigMCFBaseTaxonomy extends ITaxonomy {
-  event_type: ITaxonomyField
   implementing_agency: ITaxonomyField
   project_id: ITaxonomyField
   project_url: ITaxonomyField

--- a/src/interfaces/Config.ts
+++ b/src/interfaces/Config.ts
@@ -38,6 +38,11 @@ export type TDocumentSubTaxonomy =
 // Event sub-taxonomies.
 export interface IEventSubTaxonomy extends ISubTaxonomy {
   event_type: ITaxonomyField
+  datetime_event_name: {
+    allowed_values: string[]
+    allow_any?: boolean
+    allow_blanks?: boolean
+  }
 }
 
 // Taxonomy builder.

--- a/src/interfaces/Event.ts
+++ b/src/interfaces/Event.ts
@@ -14,14 +14,17 @@ export interface IEventFormPost {
   event_type_value: string
   family_import_id: string
   family_document_import_id?: string | null
+  metadata: IEventMetadata
 }
 
 export interface IEventFormPut {
   event_title: string
   date: Date
   event_type_value: string
+  metadata: IEventMetadata
 }
 
 export interface IEventMetadata {
   event_type: string[]
+  datetime_event_name: string[]
 }

--- a/src/tests/components/drawers/EventEditDrawer.test.tsx
+++ b/src/tests/components/drawers/EventEditDrawer.test.tsx
@@ -2,6 +2,8 @@ import '@testing-library/jest-dom'
 import { render, screen } from '@testing-library/react'
 import { EventEditDrawer } from '@/components/drawers/EventEditDrawer'
 import { formatDate } from '@/utils/formatDate'
+import userEvent from '@testing-library/user-event'
+import { TTaxonomy } from '@/interfaces'
 
 describe('EventEditDrawer', () => {
   it('renders edit form for existing event if an editingEvent is passed in', () => {
@@ -37,17 +39,37 @@ describe('EventEditDrawer', () => {
     ).toBeInTheDocument()
   })
 
-  it('renders create new event form if an editingEvent is not passed in', () => {
+  it('renders create new event form if an editingEvent is not passed in', async () => {
     render(
       <EventEditDrawer
+        familyId={'1'}
         onClose={() => {}}
         isOpen={true}
-        familyId={'1'}
-        canModify={true}
         onSuccess={() => {}}
+        canModify={false}
+        taxonomy={
+          {
+            _event: {
+              event_type: {
+                allowed_values: ['Test event type'],
+                allow_any: false,
+                allow_blanks: false,
+              },
+            },
+          } as TTaxonomy
+        }
       />,
     )
     expect(screen.getByText('Add new Event')).toBeInTheDocument()
+
+    expect(screen.getByText('Select event type')).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('combobox', { name: 'Event Type' }))
+    expect(
+      screen.getByRole('option', {
+        name: 'Test event type',
+      }),
+    ).toBeInTheDocument()
+
     expect(
       screen.getByRole('button', { name: 'Create New Event' }),
     ).toBeInTheDocument()

--- a/src/tests/components/drawers/EventEditDrawer.test.tsx
+++ b/src/tests/components/drawers/EventEditDrawer.test.tsx
@@ -6,7 +6,7 @@ import userEvent from '@testing-library/user-event'
 import { TTaxonomy } from '@/interfaces'
 
 describe('EventEditDrawer', () => {
-  it('renders edit form for existing event if an editingEvent is passed in', () => {
+  it('renders edit form for existing event if an editingEvent is passed in', async () => {
     const eventDate = new Date(2024, 6, 11).toISOString()
     // We put the formattedDate here so that the formatting runs in the same locale
     // as the test suite component when it runs formatDate.
@@ -16,7 +16,7 @@ describe('EventEditDrawer', () => {
       import_id: '1',
       event_title: 'Test event title',
       date: eventDate,
-      event_type_value: 'Appealed',
+      event_type_value: 'Test event type',
       event_status: 'Submitted',
       family_import_id: '1',
     }
@@ -27,6 +27,17 @@ describe('EventEditDrawer', () => {
         isOpen={true}
         canModify={true}
         familyId={'1'}
+        taxonomy={
+          {
+            _event: {
+              event_type: {
+                allowed_values: ['Test event type', 'Other event type'],
+                allow_any: false,
+                allow_blanks: false,
+              },
+            },
+          } as TTaxonomy
+        }
       />,
     )
     expect(
@@ -34,6 +45,15 @@ describe('EventEditDrawer', () => {
         `Edit: ${editingEvent.event_title}, on ${formattedDate}`,
       ),
     ).toBeInTheDocument()
+
+    expect(screen.getByText('Test event type')).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('combobox', { name: 'Event Type' }))
+    expect(
+      screen.getByRole('option', {
+        name: 'Other event type',
+      }),
+    ).toBeInTheDocument()
+
     expect(
       screen.getByRole('button', { name: 'Update Event' }),
     ).toBeInTheDocument()

--- a/src/tests/mocks/api/eventHandlers.ts
+++ b/src/tests/mocks/api/eventHandlers.ts
@@ -1,6 +1,7 @@
 import { http, HttpResponse } from 'msw'
-import { getEvent, updateEvent } from '../repository'
-import { IEvent } from '@/interfaces/Event'
+import { createEvent, getEvent, updateEvent } from '../repository'
+import { IEvent, IEventFormPost } from '@/interfaces/Event'
+import { extractOrgFromAuthHeader } from '@/tests/helpers'
 
 export const eventHandlers = [
   http.get('*/v1/events/:id', ({ params }) => {
@@ -14,5 +15,11 @@ export const eventHandlers = [
     updateEvent(updateData as IEvent, id as string)
     const updatedEvent = getEvent(id as string)
     return HttpResponse.json(updatedEvent)
+  }),
+  http.post('*/v1/events', async ({ request }) => {
+    const org = extractOrgFromAuthHeader(request.headers)
+    const event = await request.json()
+    const createdEventId = createEvent(event as IEventFormPost, org)
+    return HttpResponse.json(createdEventId)
   }),
 ]

--- a/src/tests/mocks/repository.ts
+++ b/src/tests/mocks/repository.ts
@@ -10,6 +10,7 @@ import {
   ICollectionFormPost,
   IDocument,
   IDocumentFormPostModified,
+  IEventFormPost,
   TFamily,
   TFamilyFormPost,
 } from '@/interfaces'
@@ -21,6 +22,20 @@ const familyRepository: TFamily[] = [...mockFamiliesData]
 
 const getEvent = (id: string) => {
   return eventRepository.find((event) => event.import_id === id)
+}
+
+const createEvent = (data: IEventFormPost, org: string) => {
+  const import_id = `${org}.event.${eventRepository.length}`
+  eventRepository.push({
+    import_id: import_id,
+    event_status: 'created',
+    ...data,
+    date:
+      data.date instanceof Date
+        ? data.date.toISOString()
+        : new Date(data.date).toISOString(),
+  })
+  return import_id
 }
 
 const updateEvent = (data: IEvent, id: string) => {
@@ -101,6 +116,7 @@ const reset = () => {
 
 export {
   getEvent,
+  createEvent,
   updateEvent,
   getDocument,
   createDocument,

--- a/src/tests/utilsTest/mocks.tsx
+++ b/src/tests/utilsTest/mocks.tsx
@@ -311,6 +311,11 @@ const mockCCLWConfig: IConfig = {
             allow_blanks: false,
             allowed_values: ['Event One', 'Event Two'],
           },
+          datetime_event_name: {
+            allow_any: false,
+            allow_blanks: false,
+            allowed_values: ['Event One'],
+          },
         },
       },
     },
@@ -365,6 +370,11 @@ const mockUNFCCCConfig: IConfig = {
             allow_any: false,
             allow_blanks: false,
             allowed_values: ['Event One', 'Event Two'],
+          },
+          datetime_event_name: {
+            allow_any: false,
+            allow_blanks: false,
+            allowed_values: ['Event One'],
           },
         },
       },

--- a/src/tests/views/FamilyEditAddEvent.test.tsx
+++ b/src/tests/views/FamilyEditAddEvent.test.tsx
@@ -1,11 +1,6 @@
-import { screen, within } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import { renderRoute } from '../utilsTest/renderRoute.tsx'
-import { mockEvent } from '@/tests/utilsTest/mocks'
-import { formatDate } from '@/utils/formatDate'
 import { setupUser } from '../helpers.ts'
-import fs from 'fs'
-import { prettyDOM } from '@testing-library/react'
-import { title } from 'process'
 
 vi.mock('react-router-dom', async (importOriginal) => {
   const actual: unknown = await importOriginal()
@@ -17,11 +12,6 @@ vi.mock('react-router-dom', async (importOriginal) => {
 
 describe('FamilyEditAddEvent', () => {
   it('successfully saves new event data', async () => {
-    // We put the formattedDate here so that the formatting runs in the same locale
-    // as the test suite component when it runs formatDate.
-
-    const formattedEventDate = formatDate(mockEvent.date)
-
     setupUser({ organisationName: 'UNFCCC', orgId: 3 })
     const { user } = renderRoute(
       '/family/mockUNFCCCFamilyNoDocumentsNoEvents/edit',
@@ -45,44 +35,30 @@ describe('FamilyEditAddEvent', () => {
       }),
     ).toBeInTheDocument()
 
-    const titleInput = screen.getByRole('textbox', { name: 'Event Title' })
-    await user.type(titleInput, 'Test event title')
+    await user.type(
+      screen.getByRole('textbox', { name: 'Event Title' }),
+      'Test event title',
+    )
 
-    const dateInput = screen.getByLabelText('Date', { selector: 'input' })
-    // await user.type(dateInput, formattedEventDate)
-    await user.type(dateInput, '2024-07-11')
-
-    // console.log(dateInput)
+    await user.type(
+      screen.getByLabelText('Date', { selector: 'input' }),
+      '2024-07-11',
+    )
 
     const eventTypeInput = screen.getByRole('combobox', { name: 'Event Type' })
-
-    await user.click(eventTypeInput)
-    const eventOption = await screen.findByRole('option', { name: 'Event One' })
-    await user.click(eventOption)
     await user.selectOptions(eventTypeInput, 'Event One')
-    const selectedOption = within(eventTypeInput).getByRole('option', {
-      selected: true,
-    })
-    console.log(selectedOption)
-    // console.log(eventTypeInput)
 
     await user.click(screen.getByRole('button', { name: 'Create New Event' }))
 
-    const domOutput = prettyDOM(document.body, 300000, { highlight: false })
-    fs.writeFileSync('debug-output.html', domOutput)
-
-    expect(
-      screen.queryByRole('button', { name: 'Create New Event' }),
-    ).not.toBeInTheDocument()
-
-    expect(
-      await screen.findByText('Event has been successfully created'),
-    ).toBeInTheDocument()
     expect(
       screen.queryByRole('dialog', {
         name: 'Add new Event',
       }),
     ).not.toBeInTheDocument()
+
+    expect(
+      await screen.findByText('Event has been successfully created'),
+    ).toBeInTheDocument()
 
     expect(await screen.findByText('Events')).toBeInTheDocument()
     expect(await screen.findByText('Test event title')).toBeInTheDocument()

--- a/src/tests/views/FamilyEditAddEvent.test.tsx
+++ b/src/tests/views/FamilyEditAddEvent.test.tsx
@@ -1,0 +1,90 @@
+import { screen, within } from '@testing-library/react'
+import { renderRoute } from '../utilsTest/renderRoute.tsx'
+import { mockEvent } from '@/tests/utilsTest/mocks'
+import { formatDate } from '@/utils/formatDate'
+import { setupUser } from '../helpers.ts'
+import fs from 'fs'
+import { prettyDOM } from '@testing-library/react'
+import { title } from 'process'
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual: unknown = await importOriginal()
+  return {
+    ...(actual as Record<string, unknown>),
+    useBlocker: vi.fn(),
+  }
+})
+
+describe('FamilyEditAddEvent', () => {
+  it('successfully saves new event data', async () => {
+    // We put the formattedDate here so that the formatting runs in the same locale
+    // as the test suite component when it runs formatDate.
+
+    const formattedEventDate = formatDate(mockEvent.date)
+
+    setupUser({ organisationName: 'UNFCCC', orgId: 3 })
+    const { user } = renderRoute(
+      '/family/mockUNFCCCFamilyNoDocumentsNoEvents/edit',
+    )
+
+    expect(
+      await screen.findByText('Editing: UNFCCC Family Three'),
+    ).toBeInTheDocument()
+
+    expect(
+      await screen.findByRole('textbox', { name: 'Title' }),
+    ).toBeInTheDocument()
+
+    expect(await screen.findByText('Events')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Add new Event' }))
+
+    expect(
+      screen.getByRole('dialog', {
+        name: 'Add new Event',
+      }),
+    ).toBeInTheDocument()
+
+    const titleInput = screen.getByRole('textbox', { name: 'Event Title' })
+    await user.type(titleInput, 'Test event title')
+
+    const dateInput = screen.getByLabelText('Date', { selector: 'input' })
+    // await user.type(dateInput, formattedEventDate)
+    await user.type(dateInput, '2024-07-11')
+
+    // console.log(dateInput)
+
+    const eventTypeInput = screen.getByRole('combobox', { name: 'Event Type' })
+
+    await user.click(eventTypeInput)
+    const eventOption = await screen.findByRole('option', { name: 'Event One' })
+    await user.click(eventOption)
+    await user.selectOptions(eventTypeInput, 'Event One')
+    const selectedOption = within(eventTypeInput).getByRole('option', {
+      selected: true,
+    })
+    console.log(selectedOption)
+    // console.log(eventTypeInput)
+
+    await user.click(screen.getByRole('button', { name: 'Create New Event' }))
+
+    const domOutput = prettyDOM(document.body, 300000, { highlight: false })
+    fs.writeFileSync('debug-output.html', domOutput)
+
+    expect(
+      screen.queryByRole('button', { name: 'Create New Event' }),
+    ).not.toBeInTheDocument()
+
+    expect(
+      await screen.findByText('Event has been successfully created'),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('dialog', {
+        name: 'Add new Event',
+      }),
+    ).not.toBeInTheDocument()
+
+    expect(await screen.findByText('Events')).toBeInTheDocument()
+    expect(await screen.findByText('Test event title')).toBeInTheDocument()
+  })
+})

--- a/src/tests/views/FamilyEditMultipleDocTypes.test.tsx
+++ b/src/tests/views/FamilyEditMultipleDocTypes.test.tsx
@@ -10,7 +10,7 @@ vi.mock('react-router-dom', async (importOriginal) => {
   }
 })
 
-describe('', () => {
+describe('FamilyEditMultipleDocTypes', () => {
   it('displays multiple document types after creating a document', async () => {
     setupUser({ organisationName: 'UNFCCC', orgId: 3 })
     const { user } = renderRoute(


### PR DESCRIPTION
# What's changed
- switch to pull event types from the _event subtaxonomy in the dropdown on the event create/edit drawer
- add a metadata field to the event create and update schemas
- make taxonomy a required prop on the EventForm component as it is now needed to obtain the value of datetime_event_name field on event metadata

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`
