### PR TITLE
Feature/app 973 enable creating and editing organisations via the admin

### DIFF
--- a/src/api/Organisations.ts
+++ b/src/api/Organisations.ts
@@ -3,7 +3,7 @@ import { AxiosError } from 'axios'
 import API from '@/api'
 import { setToken } from '@/api/Auth'
 import { IError } from '@/interfaces'
-import { IOrganisation } from '@/interfaces/Organisation'
+import { IOrganisation, IOrganisationFormPost } from '@/interfaces/Organisation'
 import { IOrganisationForm } from '@/components/forms/OrganisationForm'
 
 export async function getOrganisations() {
@@ -50,6 +50,28 @@ export async function createOrganisation(data: IOrganisationForm) {
   const response = await API.post<string>('/v1/organisations', data)
     .then((response) => {
       return response
+    })
+    .catch((error: AxiosError<{ detail: string }>) => {
+      const e: IError = {
+        status: error.response?.status || 500,
+        detail: error.response?.data?.detail || 'Unknown error',
+        message: error.message,
+      }
+      throw e
+    })
+
+  return { response }
+}
+
+export async function updateOrganisation(
+  data: IOrganisationFormPost,
+  id: number,
+) {
+  setToken(API)
+
+  const response = await API.put<IOrganisation>('/v1/organisations/' + id, data)
+    .then((response) => {
+      return response.data
     })
     .catch((error: AxiosError<{ detail: string }>) => {
       const e: IError = {

--- a/src/api/Organisations.ts
+++ b/src/api/Organisations.ts
@@ -4,6 +4,7 @@ import API from '@/api'
 import { setToken } from '@/api/Auth'
 import { IError } from '@/interfaces'
 import { IOrganisation } from '@/interfaces/Organisation'
+import { IOrganisationForm } from '@/components/forms/OrganisationForm'
 
 export async function getOrganisations() {
   setToken(API)
@@ -28,6 +29,25 @@ export async function getOrganisation(id: string) {
   setToken(API)
 
   const response = await API.get<IOrganisation>('/v1/organisations/' + id)
+    .then((response) => {
+      return response
+    })
+    .catch((error: AxiosError<{ detail: string }>) => {
+      const e: IError = {
+        status: error.response?.status || 500,
+        detail: error.response?.data?.detail || 'Unknown error',
+        message: error.message,
+      }
+      throw e
+    })
+
+  return { response }
+}
+
+export async function createOrganisation(data: IOrganisationForm) {
+  setToken(API)
+
+  const response = await API.post<string>('/v1/organisations', data)
     .then((response) => {
       return response
     })

--- a/src/components/forms/OrganisationForm.tsx
+++ b/src/components/forms/OrganisationForm.tsx
@@ -9,7 +9,7 @@ import * as Yup from 'yup'
 import { IOrganisation, IOrganisationFormPost } from '@/interfaces/Organisation'
 import { organisationSchema } from '@/schemas/organisationSchema'
 import { useNavigate } from 'react-router-dom'
-import { createOrganisation } from '@/api/Organisations'
+import { createOrganisation, updateOrganisation } from '@/api/Organisations'
 
 type TProps = {
   organisation?: IOrganisation
@@ -45,12 +45,24 @@ export const OrganisationForm = ({ organisation: loadedOrg }: TProps) => {
     }
 
     if (loadedOrg) {
-      toast({
-        title: 'Not implemented',
-        description: 'Organisation update has not been implemented',
-        status: 'error',
-        position: 'top',
-      })
+      return await updateOrganisation(organisationData, loadedOrg.id)
+        .then(() => {
+          toast.closeAll()
+          toast({
+            title: 'Organisation has been successfully updated',
+            status: 'success',
+            position: 'top',
+          })
+        })
+        .catch((error: IError) => {
+          setFormError(error)
+          toast({
+            title: 'Organisation has not been updated',
+            description: error.message,
+            status: 'error',
+            position: 'top',
+          })
+        })
     }
     return await createOrganisation(organisationData)
       .then((data) => {

--- a/src/components/lists/OrganisationList.tsx
+++ b/src/components/lists/OrganisationList.tsx
@@ -105,7 +105,7 @@ export default function OrganisationList() {
                     Type {renderSortIcon('type')}
                   </Th>
                   <Th onClick={() => {}} cursor='pointer'>
-                    Attribution Link {renderSortIcon('attribution_link')}
+                    Attribution Link {renderSortIcon('attribution_url')}
                   </Th>
                   <Th></Th>
                 </Tr>
@@ -133,7 +133,7 @@ export default function OrganisationList() {
                     <Td>{org.display_name}</Td>
                     <Td>{org.description}</Td>
                     <Td>{org.type}</Td>
-                    <Td>{org.attribution_link}</Td>
+                    <Td>{org.attribution_url}</Td>
                     <Td>
                       <HStack gap={2}>
                         <Tooltip label='Edit'>

--- a/src/interfaces/Organisation.ts
+++ b/src/interfaces/Organisation.ts
@@ -4,5 +4,13 @@ export interface IOrganisation {
   display_name: string
   description: string
   type: string
-  attribution_link: string
+  attribution_url: string
+}
+
+export interface IOrganisationFormPost {
+  internal_name: string
+  display_name: string
+  description: string
+  type: string
+  attribution_url: string
 }

--- a/src/schemas/organisationSchema.ts
+++ b/src/schemas/organisationSchema.ts
@@ -2,14 +2,10 @@ import * as yup from 'yup'
 
 export const organisationSchema = yup
   .object({
-    display_name: yup.string().when('$isNewOrg', {
-      is: false,
-      then: (schema) => schema.required(),
-      otherwise: (schema) => schema.notRequired(),
-    }),
+    display_name: yup.string().required(),
     internal_name: yup.string().required(),
     description: yup.string().required(),
     type: yup.string().required(),
-    attribution_link: yup.string().required(),
+    attribution_url: yup.string().required(),
   })
   .required()

--- a/src/tests/mocks/api/organisationHandlers.ts
+++ b/src/tests/mocks/api/organisationHandlers.ts
@@ -1,7 +1,7 @@
-import { IOrganisation, IOrganisationFormPost } from '@/interfaces/Organisation'
+import { IOrganisation } from '@/interfaces/Organisation'
 import { http, HttpResponse } from 'msw'
 
-const mockOrganisations: IOrganisation[] = [
+let mockOrganisations: IOrganisation[] = [
   {
     id: 1,
     internal_name: 'Test Organisation 1',
@@ -31,9 +31,20 @@ export const organisationHandlers = [
     )
   }),
   http.post('*/v1/organisations', async ({ request }) => {
-    const updateData = await request.json()
+    const data = await request.json()
     const id = mockOrganisations.length + 1
-    mockOrganisations.push({ ...(updateData as IOrganisationFormPost), id: id })
+    mockOrganisations.push({ ...(data as IOrganisation), id: id })
     return HttpResponse.json(id)
+  }),
+  http.put('*/v1/organisations/:id', async ({ params, request }) => {
+    const { id } = params
+    const data = await request.json()
+
+    mockOrganisations = mockOrganisations.map((org) =>
+      org.id.toString() === id ? { ...org, ...(data as IOrganisation) } : org,
+    )
+    return HttpResponse.json(
+      mockOrganisations.find((org) => org.id.toString() === id),
+    )
   }),
 ]

--- a/src/tests/mocks/api/organisationHandlers.ts
+++ b/src/tests/mocks/api/organisationHandlers.ts
@@ -1,4 +1,4 @@
-import { IOrganisation } from '@/interfaces/Organisation'
+import { IOrganisation, IOrganisationFormPost } from '@/interfaces/Organisation'
 import { http, HttpResponse } from 'msw'
 
 const mockOrganisations: IOrganisation[] = [
@@ -8,7 +8,7 @@ const mockOrganisations: IOrganisation[] = [
     display_name: 'Test Organisation 1',
     description: 'Test Description 1',
     type: 'TYPE 1',
-    attribution_link: 'test_attribution_link_1.com',
+    attribution_url: 'test_attribution_link_1.com',
   },
   {
     id: 2,
@@ -16,7 +16,7 @@ const mockOrganisations: IOrganisation[] = [
     display_name: 'Test Organisation 2',
     description: 'Test Description 2',
     type: 'TYPE 2',
-    attribution_link: 'test_attribution_link_2.com',
+    attribution_url: 'test_attribution_link_2.com',
   },
 ]
 
@@ -29,5 +29,11 @@ export const organisationHandlers = [
     return HttpResponse.json(
       mockOrganisations.find((org) => org.id.toString() === id),
     )
+  }),
+  http.post('*/v1/organisations', async ({ request }) => {
+    const updateData = await request.json()
+    const id = mockOrganisations.length + 1
+    mockOrganisations.push({ ...(updateData as IOrganisationFormPost), id: id })
+    return HttpResponse.json(id)
   }),
 ]

--- a/src/tests/views/OrganisationCreate.test.tsx
+++ b/src/tests/views/OrganisationCreate.test.tsx
@@ -20,6 +20,12 @@ describe('OrganisationCreate', () => {
     await user.type(shorthandInput, 'Test shorthand')
     expect(shorthandInput).toHaveValue('Test shorthand')
 
+    const displayNameInput = screen.getByRole('textbox', {
+      name: 'Display Name',
+    })
+    await user.type(displayNameInput, 'Test display name')
+    expect(displayNameInput).toHaveValue('Test display name')
+
     const descriptionInput = screen.getByRole('textbox', {
       name: 'Description',
     })
@@ -43,7 +49,13 @@ describe('OrganisationCreate', () => {
     )
 
     expect(
-      await screen.findByText('Organisation create has not been implemented'),
-    )
+      await screen.findByText('Organisation has been successfully created'),
+    ).toBeInTheDocument()
+    expect(
+      await screen.findByRole('heading', {
+        level: 1,
+        name: 'Editing: Test display name',
+      }),
+    ).toBeInTheDocument()
   })
 })

--- a/src/tests/views/OrganisationEdit.test.tsx
+++ b/src/tests/views/OrganisationEdit.test.tsx
@@ -59,7 +59,7 @@ describe('OrganisationEdit', () => {
     )
 
     expect(
-      await screen.findByText('Organisation update has not been implemented'),
+      await screen.findByText('Organisation has been successfully updated'),
     )
   })
 })


### PR DESCRIPTION
# What's changed
- send create and update organisation requests to the backend api so that we can actually add and edit organisations via the  admin service
