### PR TITLE
Feature/app 199 fix form helper text for textfield formatting 

### DIFF
--- a/src/components/forms/fields/TextField.tsx
+++ b/src/components/forms/fields/TextField.tsx
@@ -47,7 +47,7 @@ export const TextField = <T extends FieldValues>({
             <InputGroup>
               {type === 'number' && <InputLeftAddon children='$' />}
               <Input
-                {...field} // This destructured object contains the value
+                {...field}
                 bg='white'
                 type={type}
                 placeholder={
@@ -58,10 +58,11 @@ export const TextField = <T extends FieldValues>({
                 }
                 value={field.value ?? ''} // this prevents the component changing from a controlled to uncontrolled component
               />
-              {showHelperText && isDisabled && (
-                <FormHelperText>You cannot edit this</FormHelperText>
-              )}
             </InputGroup>
+            {/* Move helper text here, outside InputGroup */}
+            {showHelperText && isDisabled && (
+              <FormHelperText>You cannot edit this</FormHelperText>
+            )}
             {error && <FormErrorMessage>{error.message}</FormErrorMessage>}
           </FormControl>
         )

--- a/src/components/forms/fields/TextField.tsx
+++ b/src/components/forms/fields/TextField.tsx
@@ -59,7 +59,6 @@ export const TextField = <T extends FieldValues>({
                 value={field.value ?? ''} // this prevents the component changing from a controlled to uncontrolled component
               />
             </InputGroup>
-            {/* Move helper text here, outside InputGroup */}
             {showHelperText && isDisabled && (
               <FormHelperText>You cannot edit this</FormHelperText>
             )}


### PR DESCRIPTION
# What's changed

The formatting for the form helper text on the TextField component has been wrong for literally months. This closes off an ancient ticket.