### PR TITLE
refactor: make organisation attribution url nullable

### DIFF
--- a/src/components/forms/OrganisationForm.tsx
+++ b/src/components/forms/OrganisationForm.tsx
@@ -41,7 +41,9 @@ export const OrganisationForm = ({ organisation: loadedOrg }: TProps) => {
       display_name: organisation.display_name ?? '',
       description: organisation.description,
       type: organisation.type,
-      attribution_url: organisation.attribution_url,
+      attribution_url: organisation.attribution_url
+        ? organisation.attribution_url
+        : null,
     }
 
     if (loadedOrg) {
@@ -148,7 +150,7 @@ export const OrganisationForm = ({ organisation: loadedOrg }: TProps) => {
             name='attribution_url'
             label='Attribution Link'
             control={control}
-            isRequired={true}
+            isRequired={false}
           />
 
           <ButtonGroup>

--- a/src/interfaces/Organisation.ts
+++ b/src/interfaces/Organisation.ts
@@ -4,7 +4,7 @@ export interface IOrganisation {
   display_name: string
   description: string
   type: string
-  attribution_url: string
+  attribution_url: string | null
 }
 
 export interface IOrganisationFormPost {
@@ -12,5 +12,5 @@ export interface IOrganisationFormPost {
   display_name: string
   description: string
   type: string
-  attribution_url: string
+  attribution_url: string | null
 }

--- a/src/schemas/organisationSchema.ts
+++ b/src/schemas/organisationSchema.ts
@@ -6,6 +6,6 @@ export const organisationSchema = yup
     internal_name: yup.string().required(),
     description: yup.string().required(),
     type: yup.string().required(),
-    attribution_url: yup.string().required(),
+    attribution_url: yup.string().nullable(),
   })
   .required()


### PR DESCRIPTION

per title - set the attribution url as a non required field in the form

we have made an internal decision that only sabin documents will have attribution urls and the rest will remain null until we have designed a system to properly capture the intricacies of data attribution for the other corpora
