### PR TITLE
Fix cant update cclw family bug

### DIFF
--- a/src/schemas/dynamicValidationSchema.ts
+++ b/src/schemas/dynamicValidationSchema.ts
@@ -7,6 +7,25 @@ import {
 } from '@/interfaces/Metadata'
 import { TFamilyMetadata, TTaxonomy } from '@/interfaces'
 
+// Chakra single-select when taxonomy allows blanks: no value, or a complete option.
+const optionalChakraSingleSelectSchema = () =>
+  yup.mixed().test({
+    name: 'optional-chakra-single-select',
+    message: 'Invalid selection',
+    test(value: unknown) {
+      if (value === undefined || value === null) return true
+      if (typeof value !== 'object' || Array.isArray(value)) return false
+      if (Object.keys(value).length === 0) return true
+      const option = value as { value?: unknown; label?: unknown }
+      return (
+        typeof option.value === 'string' &&
+        option.value.length > 0 &&
+        typeof option.label === 'string' &&
+        option.label.length > 0
+      )
+    },
+  })
+
 // Type-safe field validation function
 const getFieldValidation = (
   fieldConfig: MetadataFieldConfig,
@@ -32,10 +51,12 @@ const getFieldValidation = (
         .min(1, 'You must provide at least one author')
       break
     case FieldType.SINGLE_SELECT:
-      fieldValidation = yup.object({
-        value: yup.string().required(),
-        label: yup.string().required(),
-      })
+      fieldValidation = isRequired
+        ? yup.object({
+            value: yup.string().required(),
+            label: yup.string().required(),
+          })
+        : optionalChakraSingleSelectSchema()
       break
     case FieldType.TEXT:
       fieldValidation = yup.string()

--- a/src/tests/utils/modifyConfig.test.ts
+++ b/src/tests/utils/modifyConfig.test.ts
@@ -42,7 +42,7 @@ describe('modifyConfig', () => {
           },
           taxonomy: {
             type: {
-              allow_blanks: false,
+              allow_blanks: true,
               allowed_values: ['type1', 'type2'],
             },
             topic: {

--- a/src/tests/utilsTest/mocks.tsx
+++ b/src/tests/utilsTest/mocks.tsx
@@ -263,7 +263,7 @@ const mockCCLWConfig: IConfig = {
       taxonomy: {
         type: {
           allow_any: false,
-          allow_blanks: false,
+          allow_blanks: true,
           allowed_values: ['Type One', 'Type Two'],
         },
         topic: {


### PR DESCRIPTION
# What's changed

We have seemingly never used Single Select chakra boxes with non required fields - adding this guard to prevent the schema validation incorrectly trying to validate the non-required single select fields as required.