### PR TITLE
feat: update metadata handlers for new metadata type

### DIFF
--- a/src/components/forms/metadata-handlers/familyForm.ts
+++ b/src/components/forms/metadata-handlers/familyForm.ts
@@ -33,6 +33,7 @@ interface IFamilyFormIntlAgreements extends IFamilyFormBase {
   author?: string
   author_type?: IChakraSelect
   external_id?: string
+  domain?: IChakraSelect[]
 }
 
 interface IFamilyFormLawsAndPolicies extends IFamilyFormBase {
@@ -43,6 +44,7 @@ interface IFamilyFormLawsAndPolicies extends IFamilyFormBase {
   keyword?: IChakraSelect[]
   framework?: IChakraSelect[]
   instrument?: IChakraSelect[]
+  domain?: IChakraSelect[]
   external_id?: string
 }
 
@@ -55,6 +57,7 @@ interface IFamilyFormMcfProjects extends IFamilyFormBase {
   project_value_co_financing?: string
   project_value_fund_spend?: string
   external_id?: string
+  domain?: IChakraSelect[]
 }
 
 interface IFamilyFormAfProjects extends IFamilyFormMcfProjects {
@@ -85,6 +88,7 @@ interface IFamilyFormReports extends IFamilyFormBase {
   author?: string[]
   author_type?: IChakraSelect[]
   external_id?: string
+  domain?: IChakraSelect[]
 }
 
 type TFamilyFormMcfProjects =
@@ -111,6 +115,7 @@ export const corpusMetadataHandlers: Record<
         author: intlData.author ? [intlData.author] : [],
         author_type: intlData.author_type ? [intlData.author_type?.value] : [],
         external_id: intlData.external_id ? [intlData.external_id] : [],
+        domain: intlData.domain?.map((domain) => domain.value) || [],
       } as IInternationalAgreementsMetadata
     },
     createSubmissionData: (baseData, metadata) =>
@@ -133,6 +138,7 @@ export const corpusMetadataHandlers: Record<
         instrument:
           lawsPolicyData.instrument?.map((instrument) => instrument.value) ||
           [],
+        domain: lawsPolicyData.domain?.map((domain) => domain.value) || [],
         external_id: lawsPolicyData.external_id
           ? [lawsPolicyData.external_id]
           : [],
@@ -164,6 +170,7 @@ export const corpusMetadataHandlers: Record<
             ? [`${afData.project_value_fund_spend}`]
             : [],
         external_id: afData.external_id ? [afData.external_id] : [],
+        domain: afData.domain?.map((domain) => domain.value) || [],
       } as IAfProjectsMetadata
     },
     createSubmissionData: (baseData, metadata) =>
@@ -192,6 +199,7 @@ export const corpusMetadataHandlers: Record<
             ? [`${cifData.project_value_fund_spend}`]
             : [],
         external_id: cifData.external_id ? [cifData.external_id] : [],
+        domain: cifData.domain?.map((domain) => domain.value) || [],
       } as ICifProjectsMetadata
     },
     createSubmissionData: (baseData, metadata) =>
@@ -226,6 +234,7 @@ export const corpusMetadataHandlers: Record<
           gcfData.result_type?.map((result_type) => result_type.value) || [],
         theme: gcfData.theme?.map((theme) => theme.value) || [],
         external_id: gcfData.external_id ? [gcfData.external_id] : [],
+        domain: gcfData.domain?.map((domain) => domain.value) || [],
       } as IGcfProjectsMetadata
     },
     createSubmissionData: (baseData, metadata) =>
@@ -255,6 +264,7 @@ export const corpusMetadataHandlers: Record<
             ? [`${gefData.project_value_fund_spend}`]
             : [],
         external_id: gefData.external_id ? [gefData.external_id] : [],
+        domain: gefData.domain?.map((domain) => domain.value) || [],
       } as IGefProjectsMetadata
     },
     createSubmissionData: (baseData, metadata) =>
@@ -270,6 +280,7 @@ export const corpusMetadataHandlers: Record<
         author: reportsData.author ? reportsData.author : [],
         author_type: reportsData.author_type?.map((type) => type.value),
         external_id: reportsData.external_id ? [reportsData.external_id] : [],
+        domain: reportsData.domain?.map((domain) => domain.value) || [],
       } as IReportsMetadata
     },
     createSubmissionData: (baseData, metadata) =>

--- a/src/interfaces/Family.ts
+++ b/src/interfaces/Family.ts
@@ -5,6 +5,7 @@ export interface IInternationalAgreementsMetadata extends IMetadata {
   author: string[]
   author_type: string[]
   external_id: string[]
+  domain: string[]
 }
 
 export interface ILawsAndPoliciesMetadata extends IMetadata {
@@ -16,6 +17,7 @@ export interface ILawsAndPoliciesMetadata extends IMetadata {
   framework: string[]
   instrument: string[]
   external_id: string[]
+  domain: string[]
 }
 
 interface IMcfProjectsBaseMetadata extends IMetadata {
@@ -27,6 +29,7 @@ interface IMcfProjectsBaseMetadata extends IMetadata {
   project_value_co_financing: string[]
   project_value_fund_spend: string[]
   external_id: string[]
+  domain: string[]
 }
 
 export interface IAfProjectsMetadata extends IMcfProjectsBaseMetadata {
@@ -53,6 +56,7 @@ export interface IReportsMetadata extends IMetadata {
   author: string[]
   author_type: string[]
   external_id: string[]
+  domain: string[]
 }
 
 type TMcfProjectsMetadata =

--- a/src/interfaces/Metadata.ts
+++ b/src/interfaces/Metadata.ts
@@ -61,6 +61,7 @@ export const CORPUS_METADATA_CONFIG: CorpusMetadataConfig = {
       keyword: { type: FieldType.MULTI_SELECT },
       framework: { type: FieldType.MULTI_SELECT },
       instrument: { type: FieldType.MULTI_SELECT },
+      domain: { type: FieldType.MULTI_SELECT },
       external_id: { type: FieldType.TEXT },
     },
     validationFields: [
@@ -72,6 +73,7 @@ export const CORPUS_METADATA_CONFIG: CorpusMetadataConfig = {
       'framework',
       'instrument',
       'external_id',
+      'domain',
     ],
   },
   AF: {
@@ -85,6 +87,7 @@ export const CORPUS_METADATA_CONFIG: CorpusMetadataConfig = {
       project_value_co_financing: { type: FieldType.NUMBER },
       project_value_fund_spend: { type: FieldType.NUMBER },
       external_id: { type: FieldType.TEXT },
+      domain: { type: FieldType.MULTI_SELECT },
     },
     validationFields: [
       'project_id',
@@ -96,6 +99,7 @@ export const CORPUS_METADATA_CONFIG: CorpusMetadataConfig = {
       'project_value_co_financing',
       'project_value_fund_spend',
       'external_id',
+      'domain',
     ],
   },
   CIF: {
@@ -109,6 +113,7 @@ export const CORPUS_METADATA_CONFIG: CorpusMetadataConfig = {
       project_value_co_financing: { type: FieldType.NUMBER },
       project_value_fund_spend: { type: FieldType.NUMBER },
       external_id: { type: FieldType.TEXT },
+      domain: { type: FieldType.MULTI_SELECT },
     },
     validationFields: [
       'project_id',
@@ -120,6 +125,7 @@ export const CORPUS_METADATA_CONFIG: CorpusMetadataConfig = {
       'project_value_co_financing',
       'project_value_fund_spend',
       'external_id',
+      'domain',
     ],
   },
   GCF: {
@@ -137,6 +143,7 @@ export const CORPUS_METADATA_CONFIG: CorpusMetadataConfig = {
       project_value_fund_spend: { type: FieldType.NUMBER },
       approved_ref: { type: FieldType.TEXT },
       external_id: { type: FieldType.TEXT },
+      domain: { type: FieldType.MULTI_SELECT },
     },
     validationFields: [
       'project_id',
@@ -152,6 +159,7 @@ export const CORPUS_METADATA_CONFIG: CorpusMetadataConfig = {
       'result_type',
       'theme',
       'external_id',
+      'domain',
     ],
   },
   GEF: {
@@ -165,6 +173,7 @@ export const CORPUS_METADATA_CONFIG: CorpusMetadataConfig = {
       project_value_co_financing: { type: FieldType.NUMBER },
       project_value_fund_spend: { type: FieldType.NUMBER },
       external_id: { type: FieldType.TEXT },
+      domain: { type: FieldType.MULTI_SELECT },
     },
     validationFields: [
       'project_id',
@@ -176,6 +185,7 @@ export const CORPUS_METADATA_CONFIG: CorpusMetadataConfig = {
       'project_value_co_financing',
       'project_value_fund_spend',
       'external_id',
+      'domain',
     ],
   },
   default: {
@@ -187,7 +197,8 @@ export const CORPUS_METADATA_CONFIG: CorpusMetadataConfig = {
       author: { type: FieldType.MULTI_VALUE_INPUT },
       author_type: { type: FieldType.MULTI_SELECT },
       external_id: { type: FieldType.TEXT },
+      domain: { type: FieldType.MULTI_SELECT },
     },
-    validationFields: ['author', 'author_type', 'external_id'],
+    validationFields: ['author', 'author_type', 'external_id', 'domain'],
   },
 }

--- a/src/tests/utilsTest/mocks.tsx
+++ b/src/tests/utilsTest/mocks.tsx
@@ -76,6 +76,7 @@ const mockUNFCCCFamily: IInternationalAgreementsFamily = {
     author: ['Author One'],
     author_type: ['Type One'],
     external_id: ['External ID One', 'External ID Two'],
+    domain: ['Climate'],
   },
 }
 
@@ -108,6 +109,7 @@ const mockCCLWFamily: ILawsAndPoliciesFamily = {
     framework: ['Framework One', 'Framework Two'],
     instrument: ['Instrument One', 'Instrument Two'],
     external_id: ['External ID One', 'External ID Two'],
+    domain: ['Climate'],
   },
 }
 
@@ -190,6 +192,7 @@ const mockGCFFamily: IReportsFamily = {
     author: ['Author One', 'Author 2'],
     author_type: ['Individual', 'Academic/Research'],
     external_id: ['1234'],
+    domain: ['Climate'],
   },
 }
 


### PR DESCRIPTION
# What's changed

Add functionality to add new domain metadata types in the admin frontend. 

Thankfully we pull through the metadata from the corpus taxonomy and populate the form fields accordingly