### PR TITLE
Feature/app 1857 allow adding subnational geographies in the admin service

### DIFF
--- a/src/api/Subdivisions.ts
+++ b/src/api/Subdivisions.ts
@@ -1,0 +1,28 @@
+import axios, { AxiosError } from 'axios'
+
+import { ISubdivision, IError } from '@/interfaces'
+
+const geographiesApi = axios.create({
+  baseURL: import.meta.env.VITE_GEOGRAPHIES_API_URL as string,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+})
+
+export async function getSubdivisions() {
+  const response = await geographiesApi
+    .get<ISubdivision[]>('/geographies/subdivisions')
+    .then((response) => {
+      return response.data
+    })
+    .catch((error: AxiosError<{ detail: string }>) => {
+      const e: IError = {
+        status: error.response?.status || 500,
+        detail: error.response?.data?.detail || 'Unknown error',
+        message: error.message,
+      }
+      throw e
+    })
+
+  return { response }
+}

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -178,16 +178,53 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
   }, [config?.corpora])
 
   const watchGeographies = watch('geographies')
+  const watchGeographiesCodes = useMemo(() => {
+    return watchGeographies ? watchGeographies.map((geo) => geo.value) : []
+  }, [watchGeographies])
+  const watchSubdivisions = watch('subdivisions')
+  const hasGeographies = watchGeographies && watchGeographies.length > 0
 
   const availableSubdivisionOptions = useMemo(() => {
     if (watchGeographies && watchGeographies.length > 0) {
-      const watchGeographiesCodes = watchGeographies.map((geo) => geo.value)
       return subdivisions.filter((subdivision) =>
         watchGeographiesCodes.includes(subdivision.country_alpha_3),
       )
     }
     return subdivisions
-  }, [watchGeographies, subdivisions])
+  }, [watchGeographies, watchGeographiesCodes, subdivisions])
+
+  useEffect(() => {
+    if (!watchSubdivisions || watchSubdivisions.length === 0) return
+    if (!watchGeographies || watchGeographies.length === 0) {
+      setValue('subdivisions', [])
+      return
+    }
+
+    const watchSubdivisionsWithParentCode = watchSubdivisions
+      .map((watchSubdivision) =>
+        subdivisions.find((sub) => sub.code === watchSubdivision.value),
+      )
+      .filter((ws) => ws !== undefined)
+
+    const validSubdivisions = watchSubdivisionsWithParentCode
+      .filter((subdivision) =>
+        watchGeographiesCodes.includes(subdivision.country_alpha_3),
+      )
+      .map((sub) => ({
+        value: sub.code,
+        label: sub.name,
+      }))
+
+    if (validSubdivisions.length !== watchSubdivisions.length) {
+      setValue('subdivisions', validSubdivisions)
+    }
+  }, [
+    watchSubdivisions,
+    watchGeographies,
+    watchGeographiesCodes,
+    subdivisions,
+    setValue,
+  ])
 
   useEffect(() => {
     if (loadedFamily) {
@@ -611,6 +648,10 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
               }))}
               isMulti={true}
               isRequired={false}
+              isDisabled={!hasGeographies}
+              placeholder={
+                hasGeographies ? 'Select...' : 'Select a geography first'
+              }
             />
             {!loadedFamily && (
               <SelectField

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -186,9 +186,11 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
 
   const availableSubdivisionOptions = useMemo(() => {
     if (watchGeographies && watchGeographies.length > 0) {
-      return subdivisions.filter((subdivision) =>
-        watchGeographiesCodes.includes(subdivision.country_alpha_3),
-      )
+      return subdivisions
+        .filter((subdivision) =>
+          watchGeographiesCodes.includes(subdivision.country_alpha_3),
+        )
+        .sort((op1, op2) => op1.name.localeCompare(op2.name))
     }
     return subdivisions
   }, [watchGeographies, watchGeographiesCodes, subdivisions])

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -181,9 +181,9 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
 
   const availableSubdivisionOptions = useMemo(() => {
     if (watchGeographies && watchGeographies.length > 0) {
-      return subdivisions.filter(
-        (subdivision) =>
-          subdivision.country_alpha_3 === watchGeographies[0].value,
+      const watchGeographiesCodes = watchGeographies.map((geo) => geo.value)
+      return subdivisions.filter((subdivision) =>
+        watchGeographiesCodes.includes(subdivision.country_alpha_3),
       )
     }
     return subdivisions

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -59,6 +59,7 @@ import {
   FieldType,
   IFormMetadata,
 } from '@/interfaces/Metadata'
+import useSubdivisions from '@/hooks/useSubdivisions'
 export interface IFamilyFormBase {
   title: string
   summary: string
@@ -90,6 +91,11 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
     error: collectionsError,
     loading: collectionsLoading,
   } = useCollections('')
+  const {
+    subdivisions,
+    error: subdivisionsError,
+    loading: subdivisionsLoading,
+  } = useSubdivisions()
   const toast = useToast()
   const [formError, setFormError] = useState<IError | null | undefined>()
 
@@ -475,7 +481,12 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
   }
 
   const canLoadForm =
-    !configLoading && !collectionsLoading && !configError && !collectionsError
+    !configLoading &&
+    !collectionsLoading &&
+    !configError &&
+    !collectionsError &&
+    !subdivisionsError &&
+    !subdivisionsLoading
 
   const blocker = useBlocker(({ currentLocation, nextLocation }) => {
     const isRouteChange = currentLocation.pathname !== nextLocation.pathname
@@ -510,8 +521,12 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
           detail='Please go back to the "Families" page, if you think there has been a mistake please contact the administrator.'
         />
       )}
-      {(configError || collectionsError || formError) && (
-        <ApiError error={configError || collectionsError || formError} />
+      {(configError || collectionsError || formError || subdivisionsError) && (
+        <ApiError
+          error={
+            configError || collectionsError || formError || subdivisionsError
+          }
+        />
       )}
 
       {canLoadForm && (
@@ -562,9 +577,9 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
               name='subdivisions'
               label='Subdivisions'
               control={control}
-              options={getCountries(config?.geographies).map((country) => ({
-                value: country.value,
-                label: country.display_value,
+              options={subdivisions?.map((subdivision) => ({
+                value: subdivision.code,
+                label: subdivision.name,
               }))}
               isMulti={true}
               isRequired={false}

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -228,13 +228,17 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
       throw new Error('No corpus type specified')
     }
 
+    const allGeographies = formData.geographies
+      ?.map((geo) => geo.value)
+      .concat(formData.subdivisions?.map((sub) => sub.value))
+
     // Prepare base family data common to all types
     const baseData: IFamilyFormPostBase = {
       title: formData.title,
       summary: stripHtml(formData.summary),
       // We still expect this value in the backend
       geography: formData.geographies?.[0].value || '',
-      geographies: formData.geographies?.map((geo) => geo.value),
+      geographies: allGeographies,
       category: formData.category,
       corpus_import_id: formData.corpus?.value || '',
       collections:
@@ -342,16 +346,27 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
         }, {})
       }
 
+      const countryGeographies = loadedFamily.geographies
+        .map((geo) =>
+          getCountries(config?.geographies)?.find((c) => c.value === geo),
+        )
+        .filter((c) => c !== undefined)
+
+      const subdivisionGeographies = loadedFamily.geographies
+        .map((geo) => subdivisions?.find((s) => s.code === geo))
+        .filter((c) => c !== undefined)
+
       // Pre-set the form values of the base family form (IFamilyFormBase) to that of the loaded family
       reset({
         title: loadedFamily.title,
         summary: loadedFamily.summary,
-        geographies: loadedFamily.geographies?.map((geography) => ({
-          value: geography,
-          label:
-            getCountries(config?.geographies)?.find(
-              (country) => country.value === geography,
-            )?.display_value || geography,
+        geographies: countryGeographies?.map((geography) => ({
+          value: geography?.value,
+          label: geography?.display_value,
+        })),
+        subdivisions: subdivisionGeographies?.map((subdivision) => ({
+          value: subdivision?.code,
+          label: subdivision?.name,
         })),
         corpus: loadedFamily.corpus_import_id
           ? {
@@ -379,7 +394,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
     } else {
       setLoadedAndReset(true)
     }
-  }, [config, loadedFamily, reset, collections, corpusInfo])
+  }, [config, loadedFamily, reset, collections, corpusInfo, subdivisions])
 
   const onAddNewEntityClick = (entityType: TChildEntity) => {
     if (!taxonomy) {

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -48,6 +48,7 @@ import {
   IChakraSelect,
   ICollection,
   IConfigCorpora,
+  ISubdivision,
   TTaxonomy,
 } from '@/interfaces'
 import {
@@ -206,7 +207,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
       .map((watchSubdivision) =>
         subdivisions.find((sub) => sub.code === watchSubdivision.value),
       )
-      .filter((ws) => ws !== undefined)
+      .filter((ws): ws is ISubdivision => ws !== undefined)
 
     const validSubdivisions = watchSubdivisionsWithParentCode
       .filter((subdivision) =>

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -63,6 +63,7 @@ export interface IFamilyFormBase {
   title: string
   summary: string
   geographies: IChakraSelect[]
+  subdivisions: IChakraSelect[]
   category: string
   corpus: IChakraSelect
   collections?: IChakraSelect[]
@@ -556,6 +557,17 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
               }))}
               isMulti={true}
               isRequired={true}
+            />
+            <SelectField
+              name='subdivisions'
+              label='Subdivisions'
+              control={control}
+              options={getCountries(config?.geographies).map((country) => ({
+                value: country.value,
+                label: country.display_value,
+              }))}
+              isMulti={true}
+              isRequired={false}
             />
             {!loadedFamily && (
               <SelectField

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -96,6 +96,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
     error: subdivisionsError,
     loading: subdivisionsLoading,
   } = useSubdivisions()
+
   const toast = useToast()
   const [formError, setFormError] = useState<IError | null | undefined>()
 
@@ -175,6 +176,18 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
       corpus?.corpus_import_id.startsWith('MCF'),
     )
   }, [config?.corpora])
+
+  const watchGeographies = watch('geographies')
+
+  const availableSubdivisionOptions = useMemo(() => {
+    if (watchGeographies && watchGeographies.length > 0) {
+      return subdivisions.filter(
+        (subdivision) =>
+          subdivision.country_alpha_3 === watchGeographies[0].value,
+      )
+    }
+    return subdivisions
+  }, [watchGeographies, subdivisions])
 
   useEffect(() => {
     if (loadedFamily) {
@@ -577,7 +590,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
               name='subdivisions'
               label='Subdivisions'
               control={control}
-              options={subdivisions?.map((subdivision) => ({
+              options={availableSubdivisionOptions?.map((subdivision) => ({
                 value: subdivision.code,
                 label: subdivision.name,
               }))}

--- a/src/components/forms/fields/SelectField.tsx
+++ b/src/components/forms/fields/SelectField.tsx
@@ -25,6 +25,8 @@ type TProps<T extends FieldValues> = {
   rules?: RegisterOptions
   isRequired?: boolean
   isClearable?: boolean
+  isDisabled?: boolean
+  placeholder?: string
 }
 
 export const SelectField = <T extends FieldValues>({
@@ -36,6 +38,8 @@ export const SelectField = <T extends FieldValues>({
   rules,
   isRequired,
   isClearable,
+  isDisabled,
+  placeholder,
 }: TProps<T>) => {
   // Determine if options are already in IChakraSelect format
   const selectOptions = options
@@ -65,7 +69,11 @@ export const SelectField = <T extends FieldValues>({
         },
       }}
       render={({ field, fieldState: { error } }) => (
-        <FormControl isInvalid={!!error} isRequired={isRequired}>
+        <FormControl
+          isInvalid={!!error}
+          isRequired={isRequired}
+          isDisabled={isDisabled}
+        >
           {label && <FormLabel>{label}</FormLabel>}
           {isMulti && (
             <FormHelperText mb={2}>
@@ -77,6 +85,8 @@ export const SelectField = <T extends FieldValues>({
             isClearable={isClearable}
             isMulti={isMulti}
             isSearchable={true}
+            isDisabled={isDisabled}
+            placeholder={placeholder}
             options={selectOptions}
             aria-label={label}
             {...field}

--- a/src/hooks/useSubdivisions.ts
+++ b/src/hooks/useSubdivisions.ts
@@ -1,0 +1,45 @@
+import { useState, useEffect } from 'react'
+
+import { IError, ISubdivision } from '@/interfaces'
+import { getSubdivisions } from '@/api/Subdivisions'
+
+let cache: ISubdivision[] | null = null
+
+const useSubdivisions = () => {
+  const [subdivisions, setSubdivisions] = useState<ISubdivision[] | []>([])
+  const [error, setError] = useState<IError | null | undefined>()
+  const [loading, setLoading] = useState<boolean>(false)
+
+  useEffect(() => {
+    let ignore = false
+    setLoading(true)
+
+    if (cache) {
+      setSubdivisions(cache)
+      setLoading(false)
+      return
+    }
+
+    getSubdivisions()
+      .then(({ response }) => {
+        if (!ignore) {
+          cache = response
+          setSubdivisions(cache)
+        }
+      })
+      .catch((error: IError) => {
+        setError(error)
+      })
+      .finally(() => {
+        setLoading(false)
+      })
+
+    return () => {
+      ignore = true
+    }
+  }, [])
+
+  return { subdivisions, error, loading }
+}
+
+export default useSubdivisions

--- a/src/interfaces/Subdivision.ts
+++ b/src/interfaces/Subdivision.ts
@@ -1,0 +1,7 @@
+export interface ISubdivision {
+  code: string
+  name: string
+  type: string
+  country_alpha_2: string
+  country_alpha_3: string
+}

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -6,6 +6,7 @@ export * from './Document'
 export * from './Event'
 export * from './Family'
 export * from './Summary'
+export * from './Subdivision'
 
 import { OptionBase } from 'chakra-react-select'
 

--- a/src/tests/components/forms/FamilyForm.test.tsx
+++ b/src/tests/components/forms/FamilyForm.test.tsx
@@ -94,9 +94,9 @@ describe('FamilyForm', () => {
 
   it('renders FamilyReadDTO data on edit', async () => {
     const testFamily = mockFamiliesData[1]
-    const { getAllByText } = renderComponent(testFamily)
-    await flushPromises()
-    const expectedEvents = getAllByText('Test event title')
+    renderComponent(testFamily)
+
+    const expectedEvents = await screen.findAllByText('Test event title')
 
     expect(screen.getByLabelText('family-import-id')).toHaveTextContent(
       testFamily.import_id,
@@ -148,9 +148,3 @@ describe('FamilyForm Icons Visibility', () => {
     expect(warningIconDocument).not.toBeInTheDocument()
   })
 })
-
-// TEST: isDirty & external navigation & internal navigation
-
-// TET: not isDirty & external navigation & internal navigation
-
-// TEST: Validators

--- a/src/tests/mocks/api/familyHandlers.ts
+++ b/src/tests/mocks/api/familyHandlers.ts
@@ -3,6 +3,7 @@ import {
   mockCCLWFamilyOneDocument,
   mockCCLWFamilyWithOneEvent,
   mockUNFCCCFamilyNoDocumentsNoEvents,
+  mockUNFCCCFamilyWithSubdivisions,
   mockFamiliesData,
   mockUNFCCCFamily,
 } from '@/tests/utilsTest/mocks'
@@ -21,6 +22,9 @@ export const familyHandlers = [
     }
     if (id === 'mockUNFCCCFamilyNoDocumentsNoEvents') {
       return HttpResponse.json({ ...mockUNFCCCFamilyNoDocumentsNoEvents })
+    }
+    if (id === 'mockUNFCCCFamilyWithSubdivisions') {
+      return HttpResponse.json({ ...mockUNFCCCFamilyWithSubdivisions })
     }
     if (id?.includes('GCF')) {
       const family = getFamily(id as string)
@@ -47,6 +51,9 @@ export const familyHandlers = [
     }
     if (id === 'mockUNFCCCFamilyNoDocumentsNoEvents') {
       return HttpResponse.json({ ...mockUNFCCCFamilyNoDocumentsNoEvents })
+    }
+    if (id === 'mockUNFCCCFamilyWithSubdivisions') {
+      return HttpResponse.json({ ...mockUNFCCCFamilyWithSubdivisions })
     }
     return HttpResponse.json({ ...mockFamiliesData[0] })
   }),

--- a/src/tests/mocks/api/geographiesHandlers.ts
+++ b/src/tests/mocks/api/geographiesHandlers.ts
@@ -17,6 +17,13 @@ export const geographiesHandlers = [
         country_alpha_2: 'BB',
         country_alpha_3: 'BBB',
       },
+      {
+        code: 'AF-BAL',
+        name: 'Balkh',
+        type: 'Province',
+        country_alpha_2: 'AF',
+        country_alpha_3: 'AFG',
+      },
     ])
   }),
 ]

--- a/src/tests/mocks/api/geographiesHandlers.ts
+++ b/src/tests/mocks/api/geographiesHandlers.ts
@@ -10,6 +10,13 @@ export const geographiesHandlers = [
         country_alpha_2: 'AA',
         country_alpha_3: 'AAA',
       },
+      {
+        code: 'BB-1',
+        name: 'Subdivision 2',
+        type: 'State',
+        country_alpha_2: 'BB',
+        country_alpha_3: 'BBB',
+      },
     ])
   }),
 ]

--- a/src/tests/mocks/api/geographiesHandlers.ts
+++ b/src/tests/mocks/api/geographiesHandlers.ts
@@ -1,0 +1,15 @@
+import { http, HttpResponse } from 'msw'
+
+export const geographiesHandlers = [
+  http.get('*/geographies/subdivisions', () => {
+    return HttpResponse.json([
+      {
+        code: 'AA-1',
+        name: 'Subdivision 1',
+        type: 'State',
+        country_alpha_2: 'AA',
+        country_alpha_3: 'AAA',
+      },
+    ])
+  }),
+]

--- a/src/tests/mocks/handlers.ts
+++ b/src/tests/mocks/handlers.ts
@@ -4,6 +4,7 @@ import { eventHandlers } from './api/eventHandlers'
 import { documentHandlers } from './api/documentHandlers'
 import { configHandlers } from './api/configHandlers'
 import { organisationHandlers } from './api/organisationHandlers'
+import { geographiesHandlers } from './api/geographiesHandlers'
 
 export const handlers = [
   ...configHandlers,
@@ -12,4 +13,5 @@ export const handlers = [
   ...eventHandlers,
   ...documentHandlers,
   ...organisationHandlers,
+  ...geographiesHandlers,
 ]

--- a/src/tests/utilsTest/mocks.tsx
+++ b/src/tests/utilsTest/mocks.tsx
@@ -28,6 +28,28 @@ const mockConfig = {
           },
           children: [],
         },
+        {
+          node: {
+            id: 1,
+            display_value: 'Country 1',
+            slug: 'country-1',
+            value: 'AAA',
+            type: 'ISO-3166',
+            parent_id: 0,
+          },
+          children: [],
+        },
+        {
+          node: {
+            id: 2,
+            display_value: 'Country 2',
+            slug: 'country-2',
+            value: 'BBB',
+            type: 'ISO-3166',
+            parent_id: 0,
+          },
+          children: [],
+        },
       ],
     },
   ],

--- a/src/tests/utilsTest/mocks.tsx
+++ b/src/tests/utilsTest/mocks.tsx
@@ -146,6 +146,20 @@ const mockUNFCCCFamilyNoDocumentsNoEvents: IInternationalAgreementsFamily = {
   last_updated_date: null,
 }
 
+const mockUNFCCCFamilyWithSubdivisions: IInternationalAgreementsFamily = {
+  ...mockUNFCCCFamily,
+  import_id: 'UNFCCC.family.4.0',
+  title: 'UNFCCC Family Four',
+  summary: 'Summary for UNFCCC Family Four with subdivisions',
+  geographies: ['AAA', 'BBB', 'AA-1', 'BB-1'],
+  documents: [],
+  events: [],
+  created: new Date(2021, 0, 5).toISOString(),
+  last_modified: new Date(2021, 0, 6).toISOString(),
+  published_date: null,
+  last_updated_date: null,
+}
+
 const mockCCLWFamilyNoDocuments: ILawsAndPoliciesFamily = {
   ...mockCCLWFamily,
   import_id: 'CCLW.family.4.0',
@@ -542,6 +556,7 @@ export { mockDocument }
 export { mockDocument2 }
 export { mockEvent }
 export { mockUNFCCCFamilyNoDocumentsNoEvents }
+export { mockUNFCCCFamilyWithSubdivisions }
 export { mockCCLWFamilyWithOneEvent }
 export { mockCCLWFamilyOneDocument }
 export { mockGCFFamily }

--- a/src/tests/views/FamilyCreate.test.tsx
+++ b/src/tests/views/FamilyCreate.test.tsx
@@ -83,4 +83,23 @@ describe('FamilyForm create', () => {
       }),
     ).toBeInTheDocument()
   })
+
+  it('allows selecting subnational geographies', async () => {
+    setupUser({ organisationName: 'GCF', orgId: 6 })
+    renderRoute('/family/new')
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Create new family' }),
+    ).toBeInTheDocument()
+
+    expect(
+      await screen.findByRole('combobox', { name: 'Geographies' }),
+    ).toBeInTheDocument()
+
+    const subdivisionInput = screen.getByRole('combobox', {
+      name: 'Subdivisions',
+    })
+
+    expect(subdivisionInput).toBeInTheDocument()
+  })
 })

--- a/src/tests/views/FamilyCreate.test.tsx
+++ b/src/tests/views/FamilyCreate.test.tsx
@@ -84,7 +84,7 @@ describe('FamilyForm create', () => {
     ).toBeInTheDocument()
   })
 
-  it('allows selecting subnational geographies', async () => {
+  it('allows selecting subdivisions', async () => {
     setupUser({ organisationName: 'GCF', orgId: 6 })
     const { user } = renderRoute('/family/new')
 
@@ -148,6 +148,61 @@ describe('FamilyForm create', () => {
 
     // check that only subdivisions of the selected geography present
     expect(screen.queryByText('Subdivision 1')).not.toBeInTheDocument()
+    expect(screen.getByText('Subdivision 2')).toBeInTheDocument()
+  })
+
+  it('allows selecting subdivisions for multiple different selected geographies', async () => {
+    setupUser({ organisationName: 'GCF', orgId: 6 })
+    const { user } = renderRoute('/family/new')
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Create new family' }),
+    ).toBeInTheDocument()
+
+    const geographiesInput = await screen.findByRole('combobox', {
+      name: 'Geographies',
+    })
+
+    await user.click(geographiesInput)
+
+    expect(screen.getByText('Country 1')).toBeInTheDocument()
+    expect(screen.getByText('Country 2')).toBeInTheDocument()
+
+    // select first geography
+    const geographyOption1 = screen.getByRole('option', {
+      name: 'Country 1',
+    })
+    await user.click(geographyOption1)
+
+    const subdivisionInput = screen.getByRole('combobox', {
+      name: 'Subdivisions',
+    })
+
+    // select first geography subdivision
+    await user.click(subdivisionInput)
+    const subdivisionOption1 = screen.getByRole('option', {
+      name: 'Subdivision 1',
+    })
+    await user.click(subdivisionOption1)
+
+    // select second geography
+    await user.click(geographiesInput)
+    const geographyOption2 = screen.getByRole('option', {
+      name: 'Country 2',
+    })
+    await user.click(geographyOption2)
+
+    // select second geography subdivision
+    await user.click(subdivisionInput)
+    const subdivisionOption2 = screen.getByRole('option', {
+      name: 'Subdivision 2',
+    })
+    await user.click(subdivisionOption2)
+
+    // check that both geographies and subdivisions are displayed
+    expect(screen.getByText('Country 1')).toBeInTheDocument()
+    expect(screen.getByText('Country 2')).toBeInTheDocument()
+    expect(screen.getByText('Subdivision 1')).toBeInTheDocument()
     expect(screen.getByText('Subdivision 2')).toBeInTheDocument()
   })
 })

--- a/src/tests/views/FamilyCreate.test.tsx
+++ b/src/tests/views/FamilyCreate.test.tsx
@@ -92,11 +92,7 @@ describe('FamilyForm create', () => {
       screen.getByRole('heading', { level: 1, name: 'Create new family' }),
     ).toBeInTheDocument()
 
-    expect(
-      await screen.findByRole('combobox', { name: 'Geographies' }),
-    ).toBeInTheDocument()
-
-    const subdivisionInput = screen.getByRole('combobox', {
+    const subdivisionInput = await screen.findByRole('combobox', {
       name: 'Subdivisions',
     })
     expect(screen.queryByText('Subdivision 1')).not.toBeInTheDocument()
@@ -110,5 +106,48 @@ describe('FamilyForm create', () => {
     await user.click(subdivisionOption)
 
     expect(screen.getByText('Subdivision 1')).toBeInTheDocument()
+  })
+
+  it('selecting a geography filters the subdivision list accordingly', async () => {
+    setupUser({ organisationName: 'GCF', orgId: 6 })
+    const { user } = renderRoute('/family/new')
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Create new family' }),
+    ).toBeInTheDocument()
+
+    const subdivisionInput = await screen.findByRole('combobox', {
+      name: 'Subdivisions',
+    })
+
+    expect(subdivisionInput).toBeInTheDocument()
+
+    await user.click(subdivisionInput)
+
+    // check all subdivisions present when no geography selected
+    expect(screen.getByText('Subdivision 1')).toBeInTheDocument()
+    expect(screen.getByText('Subdivision 2')).toBeInTheDocument()
+
+    const geographiesInput = await screen.findByRole('combobox', {
+      name: 'Geographies',
+    })
+
+    await user.click(geographiesInput)
+
+    expect(screen.getByText('Country 1')).toBeInTheDocument()
+    expect(screen.getByText('Country 2')).toBeInTheDocument()
+
+    const geographyOption = screen.getByRole('option', {
+      name: 'Country 2',
+    })
+
+    // select a geography
+    await user.click(geographyOption)
+
+    await user.click(subdivisionInput)
+
+    // check that only subdivisions of the selected geography present
+    expect(screen.queryByText('Subdivision 1')).not.toBeInTheDocument()
+    expect(screen.getByText('Subdivision 2')).toBeInTheDocument()
   })
 })

--- a/src/tests/views/FamilyCreate.test.tsx
+++ b/src/tests/views/FamilyCreate.test.tsx
@@ -86,7 +86,7 @@ describe('FamilyForm create', () => {
 
   it('allows selecting subnational geographies', async () => {
     setupUser({ organisationName: 'GCF', orgId: 6 })
-    renderRoute('/family/new')
+    const { user } = renderRoute('/family/new')
 
     expect(
       screen.getByRole('heading', { level: 1, name: 'Create new family' }),
@@ -99,7 +99,16 @@ describe('FamilyForm create', () => {
     const subdivisionInput = screen.getByRole('combobox', {
       name: 'Subdivisions',
     })
+    expect(screen.queryByText('Subdivision 1')).not.toBeInTheDocument()
 
     expect(subdivisionInput).toBeInTheDocument()
+    await user.click(subdivisionInput)
+
+    const subdivisionOption = screen.getByRole('option', {
+      name: 'Subdivision 1',
+    })
+    await user.click(subdivisionOption)
+
+    expect(screen.getByText('Subdivision 1')).toBeInTheDocument()
   })
 })

--- a/src/tests/views/FamilyCreate.test.tsx
+++ b/src/tests/views/FamilyCreate.test.tsx
@@ -84,7 +84,7 @@ describe('FamilyForm create', () => {
     ).toBeInTheDocument()
   })
 
-  it('allows selecting subdivisions', async () => {
+  it('allows creating a family with subdivisions', async () => {
     setupUser({ organisationName: 'GCF', orgId: 6 })
     const { user } = renderRoute('/family/new')
 
@@ -92,20 +92,57 @@ describe('FamilyForm create', () => {
       screen.getByRole('heading', { level: 1, name: 'Create new family' }),
     ).toBeInTheDocument()
 
+    // add title
+    await user.type(
+      await screen.findByRole('textbox', { name: 'Title' }),
+      'GCF Family with subdivision',
+    )
+    // select geography
+    await user.click(screen.getByRole('combobox', { name: 'Geographies' }))
+    const geo_option = screen.getByRole('option', {
+      name: 'Afghanistan',
+    })
+    await user.click(geo_option)
+    expect(screen.getByText('Afghanistan')).toBeInTheDocument()
+
+    // select subdivision
     const subdivisionInput = await screen.findByRole('combobox', {
       name: 'Subdivisions',
     })
-    expect(screen.queryByText('Subdivision 1')).not.toBeInTheDocument()
-
-    expect(subdivisionInput).toBeInTheDocument()
     await user.click(subdivisionInput)
 
     const subdivisionOption = screen.getByRole('option', {
-      name: 'Subdivision 1',
+      name: 'Balkh',
     })
     await user.click(subdivisionOption)
+    expect(screen.getByText('Balkh')).toBeInTheDocument()
 
-    expect(screen.getByText('Subdivision 1')).toBeInTheDocument()
+    // select corpus
+    const corpus_name = 'Climate Investment Funds Guidance'
+    await user.click(screen.getByRole('combobox', { name: 'Corpus' }))
+    const corpus_option = screen.getByRole('option', {
+      name: corpus_name,
+    })
+    await user.click(corpus_option)
+    expect(screen.getByText(corpus_name)).toBeInTheDocument()
+
+    // select category
+    await user.click(screen.getByRole('radio', { name: 'Reports (Guidance)' }))
+
+    // submit
+    await user.click(screen.getByRole('button', { name: 'Create Family' }))
+
+    expect(
+      await screen.findByText('Family has been successfully created'),
+    ).toBeInTheDocument()
+    expect(
+      await screen.findByRole('heading', {
+        level: 1,
+        name: 'Editing: GCF Family with subdivision',
+      }),
+    ).toBeInTheDocument()
+    // check subdivision was successfully saved
+    expect(screen.getByText('Balkh')).toBeInTheDocument()
   })
 
   it('selecting a geography filters the subdivision list accordingly', async () => {

--- a/src/tests/views/FamilyCreate.test.tsx
+++ b/src/tests/views/FamilyCreate.test.tsx
@@ -97,6 +97,7 @@ describe('FamilyForm create', () => {
       await screen.findByRole('textbox', { name: 'Title' }),
       'GCF Family with subdivision',
     )
+
     // select geography
     await user.click(screen.getByRole('combobox', { name: 'Geographies' }))
     const geo_option = screen.getByRole('option', {
@@ -153,18 +154,6 @@ describe('FamilyForm create', () => {
       screen.getByRole('heading', { level: 1, name: 'Create new family' }),
     ).toBeInTheDocument()
 
-    const subdivisionInput = await screen.findByRole('combobox', {
-      name: 'Subdivisions',
-    })
-
-    expect(subdivisionInput).toBeInTheDocument()
-
-    await user.click(subdivisionInput)
-
-    // check all subdivisions present when no geography selected
-    expect(screen.getByText('Subdivision 1')).toBeInTheDocument()
-    expect(screen.getByText('Subdivision 2')).toBeInTheDocument()
-
     const geographiesInput = await screen.findByRole('combobox', {
       name: 'Geographies',
     })
@@ -181,6 +170,11 @@ describe('FamilyForm create', () => {
     // select a geography
     await user.click(geographyOption)
 
+    const subdivisionInput = await screen.findByRole('combobox', {
+      name: 'Subdivisions',
+    })
+
+    expect(subdivisionInput).toBeInTheDocument()
     await user.click(subdivisionInput)
 
     // check that only subdivisions of the selected geography present

--- a/src/tests/views/FamilyEdit.test.tsx
+++ b/src/tests/views/FamilyEdit.test.tsx
@@ -113,4 +113,24 @@ describe('FamilyForm edit', () => {
     expect(screen.getByText('Subdivision 1')).toBeInTheDocument()
     expect(screen.getByText('Subdivision 2')).toBeInTheDocument()
   })
+
+  it('removes subdivision if related country is removed', async () => {
+    const { user } = renderRoute(
+      '/family/mockUNFCCCFamilyWithSubdivisions/edit',
+    )
+
+    expect(
+      await screen.findByText('Editing: UNFCCC Family Four'),
+    ).toBeInTheDocument()
+
+    expect(await screen.findByText('Country 1')).toBeInTheDocument()
+    expect(screen.getByText('Country 2')).toBeInTheDocument()
+    expect(screen.getByText('Subdivision 1')).toBeInTheDocument()
+    expect(screen.getByText('Subdivision 2')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Remove Country 1' }))
+
+    expect(screen.queryByText('Country 1')).not.toBeInTheDocument()
+    expect(screen.queryByText('Subdivision 1')).not.toBeInTheDocument()
+  })
 })

--- a/src/tests/views/FamilyEdit.test.tsx
+++ b/src/tests/views/FamilyEdit.test.tsx
@@ -100,4 +100,17 @@ describe('FamilyForm edit', () => {
     expect(await screen.findByText('New document title')).toBeInTheDocument()
     expect(screen.queryByText('Test document title')).not.toBeInTheDocument()
   })
+
+  it('correctly displays subdivision data', async () => {
+    renderRoute('/family/mockUNFCCCFamilyWithSubdivisions/edit')
+
+    expect(
+      await screen.findByText('Editing: UNFCCC Family Four'),
+    ).toBeInTheDocument()
+
+    expect(await screen.findByText('Country 1')).toBeInTheDocument()
+    expect(screen.getByText('Country 2')).toBeInTheDocument()
+    expect(screen.getByText('Subdivision 1')).toBeInTheDocument()
+    expect(screen.getByText('Subdivision 2')).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
# What's changed

Enables adding subdivisions for all corpora:

- multiple subdivisions can be selected for multiple geographies
<img width="578" height="243" alt="Screenshot 2026-05-20 at 10 51 25" src="https://github.com/user-attachments/assets/49bdee3c-9361-4fd5-99bf-f2c8316e9ca3" />

- the list of subdivisions is filtered by selected geography and sorted alphabetically
<img width="406" height="505" alt="Screenshot 2026-05-20 at 10 56 52" src="https://github.com/user-attachments/assets/fe042d8f-ee77-48dc-982f-d691bdd4775e" />

- users can only select a subdivision once a geography is selected
<img width="387" height="230" alt="Screenshot 2026-05-20 at 10 57 30" src="https://github.com/user-attachments/assets/983df413-9500-4c39-ad0f-a4964321ce77" />

- removing a geography automatically removes related subdivisions