### PR TITLE
Protect against geographies and subdivisions being undefined or null

### DIFF
--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -268,9 +268,10 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
       throw new Error('No corpus type specified')
     }
 
-    const allGeographies = formData.geographies
-      ?.map((geo) => geo.value)
+    const allGeographies = (formData.geographies ?? [])
+      .map((geo) => geo.value)
       .concat(formData.subdivisions?.map((sub) => sub.value))
+      .filter((ws): ws is string => ws !== undefined)
 
     // Prepare base family data common to all types
     const baseData: IFamilyFormPostBase = {
@@ -639,7 +640,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                 label: country.display_value,
               }))}
               isMulti={true}
-              isRequired={true}
+              isRequired={false}
             />
             <SelectField
               name='subdivisions'

--- a/src/components/forms/FamilyForm.tsx
+++ b/src/components/forms/FamilyForm.tsx
@@ -640,7 +640,7 @@ export const FamilyForm = ({ family: loadedFamily }: TProps) => {
                 label: country.display_value,
               }))}
               isMulti={true}
-              isRequired={false}
+              isRequired={true}
             />
             <SelectField
               name='subdivisions'


### PR DESCRIPTION
# What's changed

Makes sure we can create a family without adding a subdivision as we were seeing the following error:

<img width="900" height="657" alt="image (1)" src="https://github.com/user-attachments/assets/473050d6-e786-4d17-8bea-37f2d1f77615" />

