### PR TITLE
chore: add ecs deploy to merge to main workflow

### DIFF
--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -6,6 +6,7 @@ on:
 
 # trunk-ignore(checkov/CKV2_GHA_1)
 permissions: write-all
+
 jobs:
   code-quality:
     if: |
@@ -48,9 +49,9 @@ jobs:
         with:
           node-version: 22.12.0
 
-      # build
       - run: make build
 
+      # Staging
       # release
       # most of this is taken from
       # https://docs.github.com/en/actions/use-cases-and-examples/deploying/deploying-to-amazon-elastic-container-service#creating-the-workflow
@@ -77,7 +78,47 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
-      - name: Configure aws credentials (production)
+      # @see: https://github.com/marketplace/actions/amazon-ecs-deploy-express-service-action-for-github-actions#complete-example-with-all-options
+      - name: Deploy to ECS (staging)
+        id: deploy-staging
+        uses: aws-actions/amazon-ecs-deploy-express-service@v1
+        with:
+          cluster: admin-frontend-staging
+          service-name: admin-frontend-staging
+          image: ${{ secrets.DOCKER_REGISTRY_STAGING }}/navigator-admin-frontend:${{ github.sha }}
+          execution-role-arn: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID_STAGING }}:role/admin-frontend-staging-ecs-task-execution-role
+          infrastructure-role-arn: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID_STAGING }}:role/admin-frontend-staging-ecs-infrastructure-role
+
+      - name: Verify staging deployment outcome
+        env:
+          SERVICE_ARN: ${{ steps.deploy-staging.outputs.service-arn }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${SERVICE_ARN}" ]]; then
+            echo "::error::deploy step did not emit a service-arn output"
+            exit 1
+          fi
+          DEPLOY_ARN=$(aws ecs list-service-deployments \
+            --cluster admin-frontend-staging \
+            --service "${SERVICE_ARN}" \
+            --query 'serviceDeployments[0].serviceDeploymentArn' \
+            --output text)
+          if [[ -z "${DEPLOY_ARN}" || "${DEPLOY_ARN}" == "None" ]]; then
+            echo "::error::Could not find a service deployment for ${SERVICE_ARN}"
+            exit 1
+          fi
+          STATUS=$(aws ecs describe-service-deployments \
+            --service-deployment-arns "${DEPLOY_ARN}" \
+            --query 'serviceDeployments[0].status' \
+            --output text)
+          echo "Deployment ${DEPLOY_ARN} final status: ${STATUS}"
+          if [[ "${STATUS}" != "SUCCESSFUL" ]]; then
+            echo "::error::Deployment did not succeed (status=${STATUS})"
+            exit 1
+          fi
+
+      # Production
+      - name: Configure AWS credentials (production)
         uses: aws-actions/configure-aws-credentials@v5.0.0
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID_PROD }}:role/navigator-admin-frontend-github-actions
@@ -99,3 +140,42 @@ jobs:
           docker tag navigator-admin-frontend $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+        # @see: https://github.com/marketplace/actions/amazon-ecs-deploy-express-service-action-for-github-actions#complete-example-with-all-options
+      - name: Deploy to ECS (production)
+        id: deploy-production
+        uses: aws-actions/amazon-ecs-deploy-express-service@v1
+        with:
+          cluster: admin-frontend-production
+          service-name: admin-frontend-production
+          image: ${{ secrets.DOCKER_REGISTRY_PROD }}/navigator-admin-frontend:${{ github.sha }}
+          execution-role-arn: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID_PROD }}:role/admin-frontend-production-ecs-task-execution-role
+          infrastructure-role-arn: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID_PROD }}:role/admin-frontend-production-ecs-infrastructure-role
+
+      - name: Verify production deployment outcome
+        env:
+          SERVICE_ARN: ${{ steps.deploy-production.outputs.service-arn }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${SERVICE_ARN}" ]]; then
+            echo "::error::deploy step did not emit a service-arn output"
+            exit 1
+          fi
+          DEPLOY_ARN=$(aws ecs list-service-deployments \
+            --cluster admin-frontend-production \
+            --service "${SERVICE_ARN}" \
+            --query 'serviceDeployments[0].serviceDeploymentArn' \
+            --output text)
+          if [[ -z "${DEPLOY_ARN}" || "${DEPLOY_ARN}" == "None" ]]; then
+            echo "::error::Could not find a service deployment for ${SERVICE_ARN}"
+            exit 1
+          fi
+          STATUS=$(aws ecs describe-service-deployments \
+            --service-deployment-arns "${DEPLOY_ARN}" \
+            --query 'serviceDeployments[0].status' \
+            --output text)
+          echo "Deployment ${DEPLOY_ARN} final status: ${STATUS}"
+          if [[ "${STATUS}" != "SUCCESSFUL" ]]; then
+            echo "::error::Deployment did not succeed (status=${STATUS})"
+            exit 1
+          fi

--- a/src/api/Families.ts
+++ b/src/api/Families.ts
@@ -43,7 +43,7 @@ export async function getFamilies({
 
   const response = await API.get<TFamily[]>('/v1/families/', {
     params: searchParams,
-    paramsSerializer: { indexes: null }, // Allows multiple 'geography' param instances
+    paramsSerializer: { indexes: null }, // Allows multiple 'geography' param instances.
   })
     .then((response) => {
       return response

--- a/src/tests/utilsTest/render.tsx
+++ b/src/tests/utilsTest/render.tsx
@@ -3,7 +3,7 @@ import { MemoryRouter } from 'react-router-dom'
 import { render as rtlRender, RenderOptions } from '@testing-library/react'
 import { ChakraProvider } from '@chakra-ui/react'
 
-// Solution for avoid -> Error: Uncaught [TypeError: env.window.matchMedia is not a function]
+// Solution for avoid -> Error: Uncaught [TypeError: env.window.matchMedia is not a function].
 // Please check https://github.com/chakra-ui/chakra-ui/discussions/6664
 // Please check https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
 Object.defineProperty(window, 'matchMedia', {


### PR DESCRIPTION
# What's changed
Add ECS deploy on merge to main. Following the pattern we have set up in the navigator backend [ecs deploy flow ](https://github.com/climatepolicyradar/navigator-backend/blob/main/.github/workflows/deploy-ecs-service.yml)